### PR TITLE
IPv6 Support with RADIUS:

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+1.3.18
+------
+   Add support for IPv6.
+
+   Add TRACEPRINT for development level debugging.
+
 1.3.17
 ------
    Allow any number of retries, instead of only up to 3.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ LDFLAGS += -shared -Wl,--version-script=pamsymbols.ver
 #
 #  The default rule to build everything.
 #
-all: pam_radius_auth.so
+all: pam_radius_auth.so pam_radius_auth_trace.so
 
 ######################################################################
 #
@@ -37,6 +37,9 @@ all: pam_radius_auth.so
 #
 pam_radius_auth.o: pam_radius_auth.c pam_radius_auth.h
 	$(CC) $(CFLAGS) -c pam_radius_auth.c -o pam_radius_auth.o
+
+pam_radius_auth_trace.o: pam_radius_auth.c pam_radius_auth.h
+	$(CC) $(CFLAGS) -DTRACEON -c pam_radius_auth.c -o pam_radius_auth_trace.o
 #
 # This is what should work on Irix:
 #pam_radius_auth.so: pam_radius_auth.o md5.o
@@ -57,6 +60,9 @@ pam_radius_auth.o: pam_radius_auth.c pam_radius_auth.h
 #
 pam_radius_auth.so: pam_radius_auth.o md5.o
 	$(CC) $(LDFLAGS) pam_radius_auth.o md5.o -lpam -o pam_radius_auth.so
+
+pam_radius_auth_trace.so: pam_radius_auth_trace.o md5.o
+	$(CC) $(LDFLAGS) pam_radius_auth_trace.o md5.o -lpam -o pam_radius_auth_trace.so
 
 ######################################################################
 #

--- a/pam_radius_auth.c
+++ b/pam_radius_auth.c
@@ -27,6 +27,9 @@
  * 1.3.15 - Implement retry option, miscellanous bug fixes.
  * 1.3.16 - Miscellaneous fixes (see CVS for history)
  * 1.3.17 - Security fixes
+ * 1.3.18 - Added IPv6 support. Servers can be IPv4 or IPv6 addresses. In 
+ *          server config file, IPv6 addresses require brackets. Based on
+ *          patch from Alan Carwile.
  *
  *
  *   This program is free software; you can redistribute it and/or modify
@@ -65,6 +68,17 @@
 #include "pam_radius_auth.h"
 
 #define DPRINT if (ctrl & PAM_DEBUG_ARG) _pam_log
+
+/* TRACEPRINT macro can be used to produce developer-focused trace
+ * output showing more information than what is printed with the config-
+ * file requested DEBUG option. Added while extending to support IPv6.
+ * Compile with "-DTRACEON" to enable trace output.
+ */
+#ifdef TRACEON
+#define TRACEPRINT _pam_log
+#else
+#define TRACEPRINT if (0) _pam_log
+#endif
 
 /* internal data */
 static CONST char *pam_module_name = "pam_radius_auth";
@@ -130,9 +144,9 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 
     } else if (!strncmp(*argv, "client_id=", 10)) {
       if (conf->client_id) {
-	_pam_log(LOG_WARNING, "ignoring duplicate '%s'", *argv);
+        _pam_log(LOG_WARNING, "ignoring duplicate '%s'", *argv);
       } else {
-	conf->client_id = (char *) *argv+10; /* point to the client-id */
+        conf->client_id = (char *) *argv+10; /* point to the client-id */
       }
     } else if (!strcmp(*argv, "accounting_bug")) {
       conf->accounting_bug = TRUE;
@@ -158,157 +172,217 @@ void _int_free( pam_handle_t * pamh, void *x, int error_status )
     free(x);
 }
 
-/*************************************************************************
- * SMALL HELPER FUNCTIONS
- *************************************************************************/
+/*
+ * Removed ipstr2long and good_ipaddr helper functions which are IPv4 specific
+ * and no longer needed since getaddrinfo() performs validation of IP addresses.
+ * From the man page, getaddrinfo's first parameter "specifies either a numerical
+ * network address (for IPv4, numbers-and-dots notation as supported by inet_aton(3);
+ * for IPv6, hexadecimal string format as supported by inet_pton(3)), or a network
+ * hostname."  The call to getaddrinfo performs a lookup and returns a list of
+ * addrinfo structures, where each member has a sockaddr_storage structure, which
+ * contains a generic form of an IP address, supporting both IPv4 and IPv6.
+ *
+ * Note that inet_aton(3) format allows some older-style IPv4 address, such as:
+ *     10            which maps to  0.0.0.10
+ *     10.1          which maps to 10.0.0.1
+ *     10.1.1        which maps to 10.1.0.1
+ */
 
 /*
- * Return an IP address in host long notation from
- * one supplied in standard dot notation.
+ * Return a pointer to an IP address in sockaddr_storage form when given a
+ * host name, IPv4 address or IPv6 address, plus optional portstring.  Result is
+ * placed in a static structure (ssip), so the caller must copy the value
+ * out before this function gets called again.
  */
-static UINT4 ipstr2long(char *ip_str) {
-  char	buf[6];
-  char	*ptr;
-  int	i;
-  int	count;
-  UINT4	ipaddr;
-  int	cur_byte;
+static struct sockaddr_storage * get_ipaddr(char *host, char *portstring) {
+  static struct sockaddr_storage ssip;
+  struct addrinfo hintsaddr;
+  struct addrinfo *hostaddrs;
+  int rc;
+  int ctrl = 1; /* for DPRINT */
   
-  ipaddr = (UINT4)0;
-
-  for(i = 0;i < 4;i++) {
-    ptr = buf;
-    count = 0;
-    *ptr = '\0';
-
-    while(*ip_str != '.' && *ip_str != '\0' && count < 4) {
-      if(!isdigit(*ip_str)) {
-	return((UINT4)0);
-      }
-      *ptr++ = *ip_str++;
-      count++;
-    }
-
-    if(count >= 4 || count == 0) {
-      return((UINT4)0);
-    }
-
-    *ptr = '\0';
-    cur_byte = atoi(buf);
-    if(cur_byte < 0 || cur_byte > 255) {
-      return ((UINT4)0);
-    }
-
-    ip_str++;
-    ipaddr = ipaddr << 8 | (UINT4)cur_byte;
+  if (!host) {
+    DPRINT(LOG_DEBUG, "DEBUG: get_ipaddr() called with NULL host pointer.\n");
+    return ((struct sockaddr_storage *) NULL);
   }
-  return(ipaddr);
-}
 
-/*
- * Check for valid IP address in standard dot notation.
- */
-static int good_ipaddr(char *addr) {
-  int	dot_count;
-  int	digit_count;
-  
-  dot_count = 0;
-  digit_count = 0;
-  while(*addr != '\0' && *addr != ' ') {
-    if(*addr == '.') {
-      dot_count++;
-      digit_count = 0;
-    } else if(!isdigit(*addr)) {
-      dot_count = 5;
-    } else {
-      digit_count++;
-      if(digit_count > 3) {
-	dot_count = 5;
-      }
-    }
-    addr++;
+  TRACEPRINT(LOG_DEBUG, "Trace: in get_ipaddr('%s', '%s')\n", host, portstring);
+
+  /* Resolve hostname into a valid IPv4 or IPv6 address.  Uses first address
+     returned per discussion with Alan DeKok. */
+  memset(&hintsaddr, 0, sizeof(struct addrinfo));
+  hintsaddr.ai_family = AF_UNSPEC;
+  hintsaddr.ai_socktype = SOCK_DGRAM;
+  /* Considering whether AI_ADDRCONFIG should be set to scope addresses
+   * to one IPv4 only or IPv6 only, or both, depending on whether this code
+   * is running on a server with only IPv4 address, only IPv6 addresses, or
+   * a mix of both.  Also considering whether AI_V4MAPPED should be set.
+   * Neither is needed in testing thus far.  A future consideration.
+   */
+  /* hintsaddr.ai_flags = (AI_V4MAPPED | AI_ADDRCONFIG); */
+
+  if ((rc = getaddrinfo(host, portstring, &hintsaddr, &hostaddrs)) != 0) {
+    /* non-zero return code is error. */
+    DPRINT(LOG_DEBUG, "DEBUG: getaddrinfo('%s', '%s') returned %s.\n",
+        host, portstring, gai_strerror(rc));
+    return ((struct sockaddr_storage *) NULL);
   }
-  if(dot_count != 3) {
-    return(-1);
+
+  /* Format the address (numeric host) and port (numeric service) for debug */
+  char numHost[NI_MAXHOST], numService[NI_MAXSERV];
+  rc = getnameinfo((struct sockaddr *) hostaddrs->ai_addr, hostaddrs->ai_addrlen,
+                  numHost, NI_MAXHOST, numService, NI_MAXSERV,
+                  NI_NUMERICHOST | NI_NUMERICSERV);
+  if (rc == 0) {
+    DPRINT(LOG_DEBUG, "DEBUG: getaddrinfo('%s', '%s') resolved to '%s:%s'\n", host, portstring,
+           numHost, numService);
   } else {
-    return(0);
+    DPRINT(LOG_DEBUG, "DEBUG: getnameinfo: %s\n", gai_strerror(rc));
   }
+
+  /* Save result to local static variable, free getaddrinfo results, and return result */
+  memcpy(&ssip, hostaddrs->ai_addr, sizeof(struct sockaddr_storage));
+  freeaddrinfo(hostaddrs);
+  return (&ssip);
 }
 
 /*
- * Return an IP address in host long notation from a host
- * name or address in dot notation.
- */
-static UINT4 get_ipaddr(char *host) {
-  struct hostent *hp;
-  
-  if(good_ipaddr(host) == 0) {
-    return(ipstr2long(host));
+ * host2server:  Convert server->hostname to server->ssip and server->port
+ *
+ * Given a pointer to a server structure which was created from a line in the
+ * server config file, parse the server's "hostname" string, which might be a
+ * "hostname:port" but is more likely an IPv4 or IPv6 address followed by a port.
+ * Parse apart the information and perform address resolution, using
+ * getaddrinfo().  The result is a sockaddr_storage structure that handles IPv4
+ * or IPv6.  The sockaddr_storage structure gets written back to the server's
+ * server->ssip field.  The server's port string is also converted into a port number
+ * and written back to the server's server->port field.
+ *
+ * IPv6 addresses have a variable number of colons, up to seven.
+ * The port string can be a name or value, but the port string is also optional.
+ * Instead of requiring that IPv6 addresses be written in the longer form that
+ * requires all seven colons (with intervening zeros), and instead of requiring
+ * that the port string always be provided, we chose a different rule.  IPv6
+ * addresses must be placed in square brackets.
+ *
+ * From /etc/raddb/server sample:
+ *   # Server can be a hostname string or an IP address.  The :port portion is optional.
+ *   # IPv6 addresses must be enclosed in square brackets [fdca:1:2::3:4].
+ *   #
+ *   # server{:port}                   shared_secret    timeout (seconds)
+ *   vm-ac-radius-ipv6:1812             testing123          4
+ *   192.168.42.63:1812                 testing123          3
+ *   [1111:2222:3333:4444::1:3]:1812    testing123          3
 
-  } else if((hp = gethostbyname(host)) == (struct hostent *)NULL) {
-    return((UINT4)0);
-  }
-
-  return(ntohl(*(UINT4 *)hp->h_addr));
-}
-
-/*
- * take server->hostname, and convert it to server->ip and server->port
  */
 static int
 host2server(radius_server_t *server)
 {
   char *p;
   int ctrl = 1; /* for DPRINT */
+  struct sockaddr_storage * ssipptr;
+  int PORTSTRING_LEN = 256;
+  char portstring[PORTSTRING_LEN];
   
-  if ((p = strchr(server->hostname, ':')) != NULL) {
-    *(p++) = '\0';		/* split the port off from the host name */
+  TRACEPRINT(LOG_DEBUG, "Trace: in host2server\n");
+
+  /*
+   * Break down server->hostname into component parts: the hostname/ipaddress
+   * and the port string, noting that ipv6 addresses must be surrounded by 
+   * brackets to "escape/protect" the colons inside vs. the :port (optional)
+   * at the right end.
+   */
+  char *phost = server->hostname; /* start of unencumbered ipaddress or host. */
+  char *ppast = server->hostname; /* past protected [<ipv6-address>], if any. */
+  if (phost[0] == '[') {
+    *(phost++) = ' ';  /* space intentially. */
+    if ((ppast = strchr(phost, ']')) != NULL) {
+      *(ppast++) = '\0';
+    } else {
+        /* Nothing after the left-bracket - return early */
+        DPRINT(LOG_DEBUG, "DEBUG: host2server invalid server '%s'.\n", server->hostname);
+        return PAM_AUTHINFO_UNAVAIL;
+    }
   }
-  
-  if ((server->ip.s_addr = get_ipaddr(server->hostname)) == ((UINT4)0)) {
-    DPRINT(LOG_DEBUG, "DEBUG: get_ipaddr(%s) returned 0.\n", server->hostname);
-    return PAM_AUTHINFO_UNAVAIL;
+
+  /* Find and split off ':port' string. */
+  p = NULL;
+  if (ppast) {
+      if ((p = strchr(ppast, ':')) != NULL) {
+        *(p++) = '\0';              /* split the port off from the host name */
+      }
   }
+
+  /*
+   * The code above transforms the server->hostname buffer in place, and gives
+   * us two pointers to null-terminated strings in the buffer.  Below are two
+   * examples:
+   *
+   * For IPv4 or a name, from    192.168.42.63:1812 into 192.168.42.63\01812
+   * For IPv6,           from    [fdca:2::8]:1812   into  fdca:2::8\0\01812
+   *
+   * where  phost  points into it to the null-terminated host string,
+   * and    p      points into it to the null-terminated port string, 1812
+   */
 
   /*
    *  If the server port hasn't already been defined, go get it.
    */
   if (!server->port) {
-    if (p && isdigit(*p)) {	/* the port looks like it's a number */
+    if (p && isdigit(*p)) {     /* port string looks like it's a number */
       unsigned int i = atoi(p) & 0xffff;
       
       if (!server->accounting) {
-	server->port = htons((u_short) i);
+        server->port = htons((u_short) i);
       } else {
-	server->port = htons((u_short) (i + 1));
+        server->port = htons((u_short) (i + 1));
       }
-    } else {			/* the port looks like it's a name */
-      struct servent *svp;
+    } else {     /* port string might be missing or might be a service name */
+      struct servent *svp = NULL;
       
-      if (p) {			/* maybe it's not "radius" */
-	svp = getservbyname (p, "udp");
-	/* quotes allow distinction from above, lest p be radius or radacct */
-	DPRINT(LOG_DEBUG, "DEBUG: getservbyname('%s', udp) returned %d.\n", p, svp);
-	*(--p) = ':';		/* be sure to put the delimiter back */
-      } else {
-	if (!server->accounting) {
-	  svp = getservbyname ("radius", "udp");
-	  DPRINT(LOG_DEBUG, "DEBUG: getservbyname(radius, udp) returned %d.\n", svp);
-	} else {
-	  svp = getservbyname ("radacct", "udp");
-	  DPRINT(LOG_DEBUG, "DEBUG: getservbyname(radacct, udp) returned %d.\n", svp);
-	}
-      }
-      
-      if (svp == (struct servent *) 0) {
-	/* debugging above... */
-	return PAM_AUTHINFO_UNAVAIL;
+      if (p) {   /* port string is not missing, look it up, might not be "radius" */
+        TRACEPRINT(LOG_DEBUG, "DEBUG: calling getservbyname ('%s', 'udp').\n", p);
+        if ((svp = getservbyname (p, "udp")) == NULL) {
+            return PAM_AUTHINFO_UNAVAIL;
+        }
+        /* if it's the accounting stage, need to adjust to accounting port. */
+        if (server->accounting) {
+            /* convert to host order, add one, convert back to network order */
+            svp->s_port = htons(ntohs(svp->s_port) + 1);
+        }
+      } else {   /* port string is missing, so look up radius or radacct */
+        if (!server->accounting) {
+          TRACEPRINT(LOG_DEBUG, "DEBUG: calling getservbyname ('radius', 'udp').\n");
+          if ((svp = getservbyname ("radius", "udp")) == NULL) {
+            return PAM_AUTHINFO_UNAVAIL;
+          }
+        } else {
+          TRACEPRINT(LOG_DEBUG, "DEBUG: calling getservbyname ('radacct', 'udp').\n");
+          if ((svp = getservbyname ("radacct", "udp")) == NULL) {
+            return PAM_AUTHINFO_UNAVAIL;
+          }
+        }
       }
       
       server->port = svp->s_port;
     }
   }
 
+  /* Convert port back to a string for get_ipaddr / getaddrinfo calls. */
+  snprintf(portstring, PORTSTRING_LEN, "%hu", ntohs(server->port));
+  TRACEPRINT(LOG_DEBUG, "DEBUG: in host2server, port after parsing/lookup is: %s\n",
+      portstring);
+
+  /* phost is the hostname or ipaddress string without optional :port, and with ipv6
+   * brackets, if any, removed.
+   */
+  if ((ssipptr = get_ipaddr(phost, portstring)) == NULL) {
+    DPRINT(LOG_DEBUG, "DEBUG: get_ipaddr('%s', '%s') returned 0.\n", server->hostname, portstring);
+    return PAM_AUTHINFO_UNAVAIL;
+  }
+
+  /* Save resolved address as sockaddr_storage into server's ssip field */
+  memcpy(&(server->ssip), ssipptr, sizeof(struct sockaddr_storage));
   return PAM_SUCCESS;
 }
 
@@ -344,7 +418,7 @@ get_random_vector(unsigned char *vector)
     while (total < AUTH_VECTOR_LEN) {
       int bytes = read(fd, vector + total, AUTH_VECTOR_LEN - total);
       if (bytes <= 0)
-	break;			/* oops! Error */
+        break;                  /* oops! Error */
       total += bytes;
     }
     close(fd);
@@ -352,18 +426,18 @@ get_random_vector(unsigned char *vector)
 
   if (total != AUTH_VECTOR_LEN)
 #endif
-    {				/* do this *always* on other platforms */
+    {                           /* do this *always* on other platforms */
       MD5_CTX my_md5;
       struct timeval tv;
       struct timezone tz;
       static unsigned int session = 0; /* make the number harder to guess */
       
       /* Use the time of day with the best resolution the system can
-	 give us -- often close to microsecond accuracy. */
+         give us -- often close to microsecond accuracy. */
       gettimeofday(&tv,&tz);
       
       if (session == 0) {
-	session = getppid();	/* (possibly) hard to guess information */
+        session = getppid();    /* (possibly) hard to guess information */
       }
       
       tv.tv_sec ^= getpid() * session++;
@@ -372,7 +446,7 @@ get_random_vector(unsigned char *vector)
       MD5Init(&my_md5);
       MD5Update(&my_md5, (unsigned char *) &tv, sizeof(tv));
       MD5Update(&my_md5, (unsigned char *) &tz, sizeof(tz));
-      MD5Final(vector, &my_md5);	      /* set the final vector */
+      MD5Final(vector, &my_md5);              /* set the final vector */
     }
 }
 
@@ -404,8 +478,8 @@ static int
 verify_packet(char *secret, AUTH_HDR *response, AUTH_HDR *request)
 {
   MD5_CTX my_md5;
-  unsigned char	calculated[AUTH_VECTOR_LEN];
-  unsigned char	reply[AUTH_VECTOR_LEN];
+  unsigned char calculated[AUTH_VECTOR_LEN];
+  unsigned char reply[AUTH_VECTOR_LEN];
 
   /*
    * We could dispense with the memcpy, and do MD5's of the packet
@@ -453,7 +527,7 @@ find_attribute(AUTH_HDR *response, unsigned char type)
 
   while (attr->attribute != type) {
     if ((len -= attr->length) <= 0) {
-      return NULL;		/* not found */
+      return NULL;              /* not found */
     }
     attr = (attribute_t *) ((char *) attr + attr->length);
   }
@@ -471,7 +545,7 @@ add_attribute(AUTH_HDR *request, unsigned char type, CONST unsigned char *data, 
 
   p = (attribute_t *) ((unsigned char *)request + ntohs(request->length));
   p->attribute = type;
-  p->length = length + 2;		/* the total size of the attribute */
+  p->length = length + 2;               /* the total size of the attribute */
   request->length = htons(ntohs(request->length) + p->length);
   memcpy(p->data, data, length);
 }
@@ -508,12 +582,12 @@ add_password(AUTH_HDR *request, unsigned char type, CONST char *password, char *
   unsigned char *vector;
   attribute_t *attr;
 
-  if (length > MAXPASS) {	/* shorten the password for now */
+  if (length > MAXPASS) {       /* shorten the password for now */
     length = MAXPASS;
   }
 
   if (length == 0) {
-    length = AUTH_PASS_LEN;	/* 0 maps to 16 */
+    length = AUTH_PASS_LEN;     /* 0 maps to 16 */
   } if ((length & (AUTH_PASS_LEN - 1)) != 0) {
     length += (AUTH_PASS_LEN - 1); /* round it up */
     length &= ~(AUTH_PASS_LEN - 1); /* chop it off */
@@ -527,7 +601,7 @@ add_password(AUTH_HDR *request, unsigned char type, CONST char *password, char *
   if (type == PW_PASSWORD) {
     vector = request->vector;
   } else {
-    vector = attr->data;	/* attr CANNOT be NULL here. */
+    vector = attr->data;        /* attr CANNOT be NULL here. */
   }
 
   /* ************************************************************ */
@@ -535,14 +609,14 @@ add_password(AUTH_HDR *request, unsigned char type, CONST char *password, char *
   /* password : e[0] = p[0] ^ MD5(secret + vector) */
   MD5Init(&md5_secret);
   MD5Update(&md5_secret, (unsigned char *) secret, strlen(secret));
-  my_md5 = md5_secret;		/* so we won't re-do the hash later */
+  my_md5 = md5_secret;          /* so we won't re-do the hash later */
   MD5Update(&my_md5, vector, AUTH_VECTOR_LEN);
   MD5Final(misc, &my_md5);      /* set the final vector */
   xor(hashed, misc, AUTH_PASS_LEN);
   
   /* For each step through, e[i] = p[i] ^ MD5(secret + e[i-1]) */
   for (i = 1; i < (length >> 4); i++) {
-    my_md5 = md5_secret;	/* grab old value of the hash */
+    my_md5 = md5_secret;        /* grab old value of the hash */
     MD5Update(&my_md5, &hashed[(i-1) * AUTH_PASS_LEN], AUTH_PASS_LEN);
     MD5Final(misc, &my_md5);      /* set the final vector */
     xor(&hashed[i * AUTH_PASS_LEN], misc, AUTH_PASS_LEN);
@@ -563,6 +637,8 @@ static void
 cleanup(radius_server_t *server)
 {
   radius_server_t *next;
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in cleanup\n");
   
   while (server) {
     next = server->next;
@@ -580,7 +656,7 @@ cleanup(radius_server_t *server)
 static int
 initialize(radius_conf_t *conf, int accounting)
 {
-  struct sockaddr salocal;
+  struct sockaddr_in6 salocal6;
   u_short local_port;
   char hostname[BUFFER_SIZE];
   char secret[BUFFER_SIZE];
@@ -589,20 +665,21 @@ initialize(radius_conf_t *conf, int accounting)
   char *p;
   FILE *fserver;
   radius_server_t *server = NULL;
-  struct sockaddr_in * s_in;
   int timeout;
   int line = 0;
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in initialize, reading servers from file\n");
 
   /* the first time around, read the configuration file */
   if ((fserver = fopen (conf_file, "r")) == (FILE*)NULL) {
     _pam_log(LOG_ERR, "Could not open configuration file %s: %s\n",
-	    conf_file, strerror(errno));
+            conf_file, strerror(errno));
     return PAM_ABORT;
   }
   
   while (!feof(fserver) &&
-	 (fgets (buffer, sizeof(buffer), fserver) != (char*) NULL) &&
-	 (!ferror(fserver))) {
+         (fgets (buffer, sizeof(buffer), fserver) != (char*) NULL) &&
+         (!ferror(fserver))) {
     line++;
     p = buffer;
 
@@ -610,8 +687,8 @@ initialize(radius_conf_t *conf, int accounting)
      *  Skip blank lines and whitespace
      */
     while (*p &&
-	   ((*p == ' ') || (*p == '\t') ||
-	    (*p == '\r') || (*p == '\n'))) p++;
+           ((*p == ' ') || (*p == '\t') ||
+            (*p == '\r') || (*p == '\n'))) p++;
     
     /*
      *  Nothing, or just a comment.  Ignore the line.
@@ -623,18 +700,20 @@ initialize(radius_conf_t *conf, int accounting)
     timeout = 3;
     if (sscanf(p, "%s %s %d", hostname, secret, &timeout) < 2) {
       _pam_log(LOG_ERR, "ERROR reading %s, line %d: Could not read hostname or secret\n",
-	       conf_file, line);
+               conf_file, line);
       continue; /* invalid line */
-    } else {			/* read it in and save the data */
+    } else {                    /* read it in and save the data */
       radius_server_t *tmp;
       
+      TRACEPRINT(LOG_DEBUG, "Trace: in initialize, read server: %s %s %d\n", hostname, secret, timeout);
+
       tmp = malloc(sizeof(radius_server_t));
       if (server) {
-	server->next = tmp;
-	server = server->next;
+        server->next = tmp;
+        server = server->next;
       } else {
-	conf->server = tmp;
-	server= tmp;		/* first time */
+        conf->server = tmp;
+        server= tmp;            /* first time */
       }
       
       /* sometime later do memory checks here */
@@ -644,51 +723,85 @@ initialize(radius_conf_t *conf, int accounting)
       server->port = 0;
 
       if ((timeout < 1) || (timeout > 60)) {
-	server->timeout = 3;
+        server->timeout = 3;
       } else {
-	server->timeout = timeout;
+        server->timeout = timeout;
       }
       server->next = NULL;
     }
   }
   fclose(fserver);
   
-  if (!server) {		/* no server found, die a horrible death */
+  if (!server) {                /* no server found, die a horrible death */
     _pam_log(LOG_ERR, "No RADIUS server found in configuration file %s\n",
-	     conf_file);
+             conf_file);
     return PAM_AUTHINFO_UNAVAIL;
   }
   
+  TRACEPRINT(LOG_DEBUG, "Trace: in initialize, creating socket conf->sockfd\n");
+
   /* open a socket.  Dies if it fails */
-  conf->sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (conf->sockfd < 0) {
+  conf->sockfd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+  if (conf->sockfd <= 0) {
     _pam_log(LOG_ERR, "Failed to open RADIUS socket: %s\n", strerror(errno));
     return PAM_AUTHINFO_UNAVAIL;
   }
 
-  /* set up the local end of the socket communications */
-  s_in = (struct sockaddr_in *) &salocal;
-  memset ((char *) s_in, '\0', sizeof(struct sockaddr));
-  s_in->sin_family = AF_INET;
-  s_in->sin_addr.s_addr = INADDR_ANY;
-
-  /*
-   *  Use our process ID as a local port for RADIUS.
+  /* Set option to allow socket to do both IPv4 and IPv6 communications. Some
+   * OS's default this option to on, and some to off. It may vary depending
+   * on the particular release number of an operating system.  Use the command
+   *   $ sysctl  -a | grep ipv6.bindv6only
+   *   net.ipv6.bindv6only = 0
+   * to find a system's default value. However, we still force the setting.
    */
-  local_port = (getpid() & 0x7fff) + 1024;
-  do {
-    local_port++;
-    s_in->sin_port = htons(local_port);
-  } while ((bind(conf->sockfd, &salocal, sizeof (struct sockaddr_in)) < 0) && 
-	   (local_port < 64000));
-  
-  if (local_port >= 64000) {
-    close(conf->sockfd);
-    _pam_log(LOG_ERR, "No open port we could bind to.");
+  int no = 0;
+  if ((setsockopt(conf->sockfd, SOL_IPV6, IPV6_V6ONLY, &no, sizeof(no))) < 0) {
+    _pam_log(LOG_ERR, "Failure turning off IPV6_V6ONLY. setsockopt error: %s.", strerror(errno));
     return PAM_AUTHINFO_UNAVAIL;
   }
+                                             
+  /* set up the local end of the socket communications */
+  memset ((char *) &salocal6, '\0', sizeof(struct sockaddr_in6));
+  salocal6.sin6_family = AF_INET6;
+  salocal6.sin6_addr = in6addr_any;
 
+  /*
+   *  Previous versions looped to try different local ports based from process's pid,
+   *  but we now let the stack pick the local port by specifying zero as port.
+   */
+  local_port = 0;
+  salocal6.sin6_port = htons(local_port);
+
+  TRACEPRINT(LOG_DEBUG, "Trace: binding conf->sockfd\n");
+  if (bind(conf->sockfd, (struct sockaddr *) &salocal6, sizeof (struct sockaddr_in6)) < 0) {
+    int errsave = errno;
+    close(conf->sockfd);
+    _pam_log(LOG_ERR, "No open port we could bind to.  bind error: %s.", strerror(errsave));
+    return PAM_AUTHINFO_UNAVAIL;
+  }
+      
   return PAM_SUCCESS;
+}
+
+/*
+ * The IP address for the client is placed in the RADIUS packet and tagged
+ * according to the type (IP for AF_INET, IPV6 for AF_INET6).
+ */
+static void
+add_ssip_attribute(AUTH_HDR *request, struct sockaddr_storage * ssipptr)
+{
+  switch (ssipptr->ss_family) {
+  case AF_INET:
+      add_attribute(request, PW_NAS_IP_ADDRESS,
+          (unsigned char *)&((struct sockaddr_in *)ssipptr)->sin_addr, 4);
+      break;
+  case AF_INET6:
+      add_attribute(request, PW_NAS_IPV6_ADDRESS,
+          (unsigned char *)&((struct sockaddr_in6 *)ssipptr)->sin6_addr, 16);
+      break;
+  default:
+      break;
+  }
 }
 
 /*
@@ -698,15 +811,27 @@ initialize(radius_conf_t *conf, int accounting)
 static void
 build_radius_packet(AUTH_HDR *request, CONST char *user, CONST char *password, radius_conf_t *conf)
 {
-  char hostname[256];
-  UINT4 ipaddr;
+  char hostname[HOST_NAME_MAX+1];
+  struct sockaddr_storage * ssipptr;
+  int rc;
   
+  TRACEPRINT(LOG_DEBUG, "Trace: in build_radius_packet\n");
+
+  /* Use IPv4 loopback if we cannot determine hostname of this system */
   hostname[0] = '\0';
-  gethostname(hostname, sizeof(hostname) - 1);
+  if ((rc = gethostname(hostname, HOST_NAME_MAX)) < 0) {
+    int errsave = errno;
+    _pam_log(LOG_ERR, "Attempt to gethostname failed with error: %s.", strerror(errsave));
+    strcpy(hostname, "127.0.0.1");
+  }
+  /* With very long names, some systems don't make sure result is null-terminated. */
+  hostname[HOST_NAME_MAX] = '\0';
+  /* If name could not be retrieved, use the loopback address. */
+  if (!(hostname[0])) strcpy(hostname, "127.0.0.1");
 
   request->length = htons(AUTH_HDR_LEN);
 
-  if (password) {		/* make a random authentication req vector */
+  if (password) {               /* make a random authentication req vector */
     get_random_vector(request->vector);
   }
   
@@ -725,28 +850,19 @@ build_radius_packet(AUTH_HDR *request, CONST char *user, CONST char *password, r
     add_password(request, PW_PASSWORD, "", conf->server->secret);
   }
 
-  /* the packet is from localhost if on localhost, to make configs easier */
-  if ((conf->server->ip.s_addr == ntohl(0x7f000001)) || (!hostname[0])) {
-    ipaddr = 0x7f000001;
-  } else {
-    struct hostent *hp;
-    
-    if ((hp = gethostbyname(hostname)) == (struct hostent *) NULL) {
-      ipaddr = 0x00000000;	/* no client IP address */
-    } else {
-      ipaddr = ntohl(*(UINT4 *) hp->h_addr); /* use the first one available */
-    }
-  }
-
-  /* If we can't find an IP address, then don't add one */
-  if (ipaddr) {
-    add_int_attribute(request, PW_NAS_IP_ADDRESS, ipaddr);
+  /*
+   * Convert this host's hostname into an ip address if possible.
+   * When looking up this host's ip address, note that the port is not meaningful, hence "".
+   * If we can't determine an IP address, then don't add one.
+   */
+  if ((ssipptr = get_ipaddr(hostname, "")) != NULL) {
+    add_ssip_attribute(request, ssipptr);
   }
 
   /* There's always a NAS identifier */
   if (conf->client_id && *conf->client_id) {
     add_attribute(request, PW_NAS_IDENTIFIER, (unsigned char *) conf->client_id,
-		  strlen(conf->client_id));
+                  strlen(conf->client_id));
   }
 
   /*
@@ -772,12 +888,13 @@ talk_radius(radius_conf_t *conf, AUTH_HDR *request, AUTH_HDR *response,
   struct timeval tv;
   time_t now, end;
   int rcode;
-  struct sockaddr saremote;
-  struct sockaddr_in *s_in = (struct sockaddr_in *) &saremote;
+  struct sockaddr_storage saremote;
   radius_server_t *server = conf->server;
   int ok;
   int server_tries;
   int retval;
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius\n");
 
   /* ************************************************************ */
   /* Now that we're done building the request, we can send it */
@@ -798,41 +915,44 @@ talk_radius(radius_conf_t *conf, AUTH_HDR *request, AUTH_HDR *response,
     /* only look up IP information as necessary */
     if ((retval = host2server(server)) != PAM_SUCCESS) {
       _pam_log(LOG_ERR,
-	       "Failed looking up IP address for RADIUS server %s (errcode=%d)",
-	       server->hostname, retval);
+               "Failed looking up IP address for RADIUS server %s (errcode=%d)",
+               server->hostname, retval);
       ok = FALSE;
-      goto next;		/* skip to the next server */
+      goto next;                /* skip to the next server */
     }
 
-    /* set up per-server IP && port configuration */
-    memset ((char *) s_in, '\0', sizeof(struct sockaddr));
-    s_in->sin_family = AF_INET;
-    s_in->sin_addr.s_addr = htonl(server->ip.s_addr);
-    s_in->sin_port = server->port;
     total_length = ntohs(request->length);
     
-    if (!password) { 		/* make an RFC 2139 p6 request authenticator */
+    if (!password) {            /* make an RFC 2139 p6 request authenticator */
       get_accounting_vector(request, server);
     }
 
     server_tries = tries;
 send:
+
+    if (server->ssip.ss_family == AF_INET) {
+        salen = sizeof (struct sockaddr_in);
+    } else {
+        salen = sizeof (struct sockaddr_in6);
+    }
+
+    TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius, sending on conf->sockfd\n");
+
     /* send the packet */
     if (sendto(conf->sockfd, (char *) request, total_length, 0,
-	       &saremote, sizeof(struct sockaddr_in)) < 0) {
+               ((struct sockaddr *)&(server->ssip)), salen) < 0) {
       _pam_log(LOG_ERR, "Error sending RADIUS packet to server %s: %s",
-	       server->hostname, strerror(errno));
+               server->hostname, strerror(errno));
       ok = FALSE;
-      goto next;		/* skip to the next server */
+      goto next;                /* skip to the next server */
     }
 
     /* ************************************************************ */
     /* Wait for the response, and verify it. */
-    salen = sizeof(struct sockaddr);
     tv.tv_sec = server->timeout; /* wait for the specified time */
     tv.tv_usec = 0;
-    FD_ZERO(&set);		/* clear out the set */
-    FD_SET(conf->sockfd, &set);	/* wait only for the RADIUS UDP socket */
+    FD_ZERO(&set);              /* clear out the set */
+    FD_SET(conf->sockfd, &set); /* wait only for the RADIUS UDP socket */
     
     time(&now);
     end = now + tv.tv_sec;
@@ -841,111 +961,116 @@ send:
     ok = TRUE;
     while (ok) {
 
+      TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius, at select call\n");
+
       rcode = select(conf->sockfd + 1, &set, NULL, NULL, &tv);
 
       /* select timed out */
       if (rcode == 0) {
-	_pam_log(LOG_ERR, "RADIUS server %s failed to respond",
-		 server->hostname);
-	if (--server_tries)
-	  goto send;
-	ok = FALSE;
-	break;			/* exit from the select loop */
+        _pam_log(LOG_ERR, "RADIUS server %s failed to respond, time out",
+                 server->hostname);
+        if (--server_tries)
+          goto send;
+        ok = FALSE;
+        break;                  /* exit from the select loop */
       } else if (rcode < 0) {
 
-	/* select had an error */
-	if (errno == EINTR) {	/* we were interrupted */
-	  time(&now);
-	  
-	  if (now > end) {
-	    _pam_log(LOG_ERR, "RADIUS server %s failed to respond",
-		     server->hostname);
-	    if (--server_tries)
-	      goto send;
-	    ok = FALSE;
-	    break;			/* exit from the select loop */
-	  }
-	  
-	  tv.tv_sec = end - now;
-	  if (tv.tv_sec == 0) {	/* keep waiting */
-	    tv.tv_sec = 1;
-	  }
+        /* select had an error */
+        if (errno == EINTR) {   /* we were interrupted */
+          time(&now);
+          
+          if (now > end) {
+            _pam_log(LOG_ERR, "RADIUS server %s failed to respond, interrupted",
+                     server->hostname);
+            if (--server_tries)
+              goto send;
+            ok = FALSE;
+            break;                      /* exit from the select loop */
+          }
+          
+          tv.tv_sec = end - now;
+          if (tv.tv_sec == 0) { /* keep waiting */
+            tv.tv_sec = 1;
+          }
 
-	} else {		/* not an interrupt, it was a real error */
-	  _pam_log(LOG_ERR, "Error waiting for response from RADIUS server %s: %s",
-		   server->hostname, strerror(errno));
-	  ok = FALSE;
-	  break;
-	}
+        } else {                /* not an interrupt, it was a real error */
+          _pam_log(LOG_ERR, "Error waiting for response from RADIUS server %s: %s",
+                   server->hostname, strerror(errno));
+          ok = FALSE;
+          break;
+        }
 
-	/* the select returned OK */
+        /* the select returned OK */
       } else if (FD_ISSET(conf->sockfd, &set)) {
 
-	/* try to receive some data */
-	if ((total_length = recvfrom(conf->sockfd, (void *) response,
-				     BUFFER_SIZE,
-				     0, &saremote, &salen)) < 0) {
-	  _pam_log(LOG_ERR, "error reading RADIUS packet from server %s: %s",
-		   server->hostname, strerror(errno));
-	  ok = FALSE;
-	  break;
+        TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius, calling recvfrom on conf-sockfd\n");
+        
+        /* try to receive some data */
+        salen = sizeof(struct sockaddr_storage); /* init large enough for ipv4 or ipv6 */
+        if ((total_length = recvfrom(conf->sockfd, (void *) response,
+                                     BUFFER_SIZE,
+                                     0, (struct sockaddr *)&saremote, &salen)) < 0) {
+          _pam_log(LOG_ERR, "error reading RADIUS packet from server %s: %s",
+                   server->hostname, strerror(errno));
+          ok = FALSE;
+          break;
 
-	  /* there's data, see if it's valid */
-	} else {
-	  char *p = server->secret;
-	  
-	  if ((ntohs(response->length) != total_length) ||
-	      (ntohs(response->length) > BUFFER_SIZE)) {
-	    _pam_log(LOG_ERR, "RADIUS packet from server %s is corrupted",
-		     server->hostname);
-	    ok = FALSE;
-	    break;
-	  }
+        } else {
+          /* there's data, see if it's valid */
+          char *p = server->secret;
+          
+          if ((ntohs(response->length) != total_length) ||
+              (ntohs(response->length) > BUFFER_SIZE)) {
+            _pam_log(LOG_ERR, "RADIUS packet from server %s is corrupted",
+                     server->hostname);
+            ok = FALSE;
+            break;
+          }
 
-	  /* Check if we have the data OK.  We should also check request->id */
+          /* Check if we have the data OK.  We should also check request->id */
 
-	  if (password) {
-	    if (old_password) {
+          if (password) {
+            if (old_password) {
 #ifdef LIVINGSTON_PASSWORD_VERIFY_BUG_FIXED
-	      p = old_password;	/* what it should be */
+              p = old_password; /* what it should be */
 #else
-	      p = "";		/* what it really is */
+              p = "";           /* what it really is */
 #endif
-	    }
-	    /* 
-	     * RFC 2139 p.6 says not do do this, but the Livingston 1.16
-	     * server disagrees.  If the user says he wants the bug, give in.
-	     */
-	  } else {		/* authentication request */
-	    if (conf->accounting_bug) {
-	      p = "";
-	    }
-	  }
-	    
-	  if (!verify_packet(p, response, request)) {
-	    _pam_log(LOG_ERR, "packet from RADIUS server %s fails verification: The shared secret is probably incorrect.",
-		     server->hostname);
-	    ok = FALSE;
-	    break;
-	  }
+            }
+            /* 
+             * RFC 2139 p.6 says not do do this, but the Livingston 1.16
+             * server disagrees.  If the user says he wants the bug, give in.
+             */
+          } else {              /* authentication request */
+            if (conf->accounting_bug) {
+              p = "";
+            }
+          }
+            
+          if (!verify_packet(p, response, request)) {
+            _pam_log(LOG_ERR, "packet from RADIUS server %s fails verification: The shared secret is probably incorrect.",
+                     server->hostname);
+            ok = FALSE;
+            break;
+          }
 
-	  /*
-	   * Check that the response ID matches the request ID.
-	   */
-	  if (response->id != request->id) {
-	    _pam_log(LOG_WARNING, "Response packet ID %d does not match the request packet ID %d: verification of packet fails", response->id, request->id);
-	      ok = FALSE;
-	    break;
-	  }
-	}
-	
-	/*
-	 * Whew!  The select is done.  It hasn't timed out, or errored out.
-	 * It's our descriptor.  We've got some data.  It's the right size.
-	 * The packet is valid.
-	 * NOW, we can skip out of the select loop, and process the packet
-	 */
-	break;
+          /*
+           * Check that the response ID matches the request ID.
+           */
+          if (response->id != request->id) {
+            _pam_log(LOG_WARNING, "Response packet ID %d does not match the request packet ID %d: verification of packet fails", response->id, request->id);
+              ok = FALSE;
+            break;
+          }
+        }
+        
+        /*
+         * Whew!  The select is done.  It hasn't timed out, or errored out.
+         * It's our descriptor.  We've got some data.  It's the right size.
+         * The packet is valid.
+         * NOW, we can skip out of the select loop, and process the packet
+         */
+        break;
       }
       /* otherwise, we've got data on another descriptor, keep select'ing */
     }
@@ -953,7 +1078,7 @@ send:
     /* go to the next server if this one didn't respond */
   next:
     if (!ok) {
-      radius_server_t *old;	/* forget about this server */
+      radius_server_t *old;     /* forget about this server */
       
       old = server;
       server = server->next;
@@ -963,29 +1088,35 @@ send:
       free(old->hostname);
       free(old);
 
-      if (server) {		/* if there's more servers to check */
-	/* get a new authentication vector, and update the passwords */
-	get_random_vector(request->vector);
-	request->id = request->vector[0];
-	
-	/* update passwords, as appropriate */
-	if (password) {
-	  get_random_vector(request->vector);
-	  if (old_password) {	/* password change request */
-	    add_password(request, PW_PASSWORD, password, old_password);
-	    add_password(request, PW_OLD_PASSWORD, old_password, old_password);
-	  } else {		/* authentication request */
-	    add_password(request, PW_PASSWORD, password, server->secret);
-	  }
-	}
+      if (server) {             /* if there's more servers to check */
+
+        TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius, proceeding to next server\n");
+
+        /* get a new authentication vector, and update the passwords */
+        get_random_vector(request->vector);
+        request->id = request->vector[0];
+        
+        /* update passwords, as appropriate */
+        if (password) {
+          get_random_vector(request->vector);
+          if (old_password) {   /* password change request */
+            add_password(request, PW_PASSWORD, password, old_password);
+            add_password(request, PW_OLD_PASSWORD, old_password, old_password);
+          } else {              /* authentication request */
+            add_password(request, PW_PASSWORD, password, server->secret);
+          }
+        }
       }
       continue;
 
     } else {
       /* we've found one that does respond, forget about the other servers */
+
+      TRACEPRINT(LOG_DEBUG, "Trace: in talk_radius, found server that does respond\n");
+
       cleanup(server->next);
       server->next = NULL;
-      live_server = server;	/* we've got a live one! */
+      live_server = server;     /* we've got a live one! */
       break;
     }
   }
@@ -1020,6 +1151,8 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, char *message, char *
   struct pam_response *resp = NULL;
   int retval;
   
+  TRACEPRINT(LOG_DEBUG, "Trace: in rad_converse\n");
+
   resp_msg.msg_style = msg_style;
   resp_msg.msg = message;
   msg[0] = &resp_msg;
@@ -1031,7 +1164,7 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, char *message, char *
   retval = conv->conv(1, msg, &resp,conv->appdata_ptr);
   PAM_FAIL_CHECK;
   
-  if (password) {		/* assume msg.type needs a response */
+  if (password) {               /* assume msg.type needs a response */
     /* I'm not sure if this next bit is necessary on Linux */
 #ifdef sun
     /* NULL response, fail authentication */
@@ -1052,12 +1185,12 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, char *message, char *
  **************************************************************************/
 
 #undef PAM_FAIL_CHECK
-#define PAM_FAIL_CHECK if (retval != PAM_SUCCESS) {	\
-	int *pret = malloc( sizeof(int) );		\
-	*pret = retval;					\
-	pam_set_data( pamh, "rad_setcred_return"	\
-	              , (void *) pret, _int_free );	\
-	return retval; }
+#define PAM_FAIL_CHECK if (retval != PAM_SUCCESS) {     \
+        int *pret = malloc( sizeof(int) );              \
+        *pret = retval;                                 \
+        pam_set_data( pamh, "rad_setcred_return"        \
+                      , (void *) pret, _int_free );     \
+        return retval; }
 
 PAM_EXTERN int 
 pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
@@ -1075,6 +1208,8 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
   AUTH_HDR *request = (AUTH_HDR *) send_buffer;
   AUTH_HDR *response = (AUTH_HDR *) recv_buffer;
   radius_conf_t config;
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_authenticate\n");
 
   ctrl = _pam_parse(argc, argv, &config);
 
@@ -1144,13 +1279,14 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
   /* no previous password: maybe get one from the user */
   if (!password) {
     if (ctrl & PAM_USE_FIRST_PASS) {
-      retval = PAM_AUTH_ERR;	/* use one pass only, stopping if it fails */
+      retval = PAM_AUTH_ERR;    /* use one pass only, stopping if it fails */
       goto error;
     }
     
     /* check to see if we send a NULL password the first time around */
     if (!(ctrl & PAM_SKIP_PASSWD)) {
       retval = rad_converse(pamh, PAM_PROMPT_ECHO_OFF, "Password: ", &password);
+      TRACEPRINT(LOG_DEBUG, "Trace: Back in pam_sm_authenticate (1), after rad_converse\n");
       PAM_FAIL_CHECK;
 
     }
@@ -1170,7 +1306,7 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
   PAM_FAIL_CHECK;
   if (rhost) {
     add_attribute(request, PW_CALLING_STATION_ID, (unsigned char *) rhost,
-		  strlen(rhost));
+                  strlen(rhost));
   }
 
   DPRINT(LOG_DEBUG, "Sending RADIUS request code %d", request->code);
@@ -1194,7 +1330,7 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
 
     /* Now we do a bit more work: challenge the user, and get a response */
     if (((a_state = find_attribute(response, PW_STATE)) == NULL) ||
-	((a_reply = find_attribute(response, PW_REPLY_MESSAGE)) == NULL)) {
+        ((a_reply = find_attribute(response, PW_REPLY_MESSAGE)) == NULL)) {
       /* Actually, State isn't required. */
       _pam_log(LOG_ERR, "RADIUS Access-Challenge received with State or Reply-Message missing");
       retval = PAM_AUTHINFO_UNAVAIL;
@@ -1202,7 +1338,7 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
     }
 
     /*
-     *	Security fixes.
+     *  Security fixes.
      */
     if ((a_state->length <= 2) || (a_reply->length <= 2)) {
       _pam_log(LOG_ERR, "RADIUS Access-Challenge received with invalid State or Reply-Message");
@@ -1215,11 +1351,12 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
 
     /* It's full challenge-response, we should have echo on */
     retval = rad_converse(pamh, PAM_PROMPT_ECHO_ON, challenge, &resp2challenge);
+    TRACEPRINT(LOG_DEBUG, "Trace: Back in pam_sm_authenticate (2), after rad_converse\n");
 
     /* now that we've got a response, build a new radius packet */
     build_radius_packet(request, user, resp2challenge, &config);
     /* request->code is already PW_AUTHENTICATION_REQUEST */
-    request->id++;		/* one up from the request */
+    request->id++;              /* one up from the request */
 
     /* copy the state over from the servers response */
     add_attribute(request, PW_STATE, a_state->data, a_state->length - 2);
@@ -1234,7 +1371,7 @@ pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
   if (response->code == PW_AUTHENTICATION_ACK) {
     retval = PAM_SUCCESS;
   } else {
-    retval = PAM_AUTH_ERR;	/* authentication failure */
+    retval = PAM_AUTH_ERR;      /* authentication failure */
 
 error:
     /* If there was a password pass it to the next layer */
@@ -1245,9 +1382,11 @@ error:
 
   if (ctrl & PAM_DEBUG_ARG) {
     _pam_log(LOG_DEBUG, "authentication %s"
-	     , retval==PAM_SUCCESS ? "succeeded":"failed" );
+             , retval==PAM_SUCCESS ? "succeeded":"failed" );
   }
   
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_authenticate, closing config.sockfd and cleanup server list\n");
+
   close(config.sockfd);
   cleanup(config.server);
   _pam_forget(password);
@@ -1282,8 +1421,8 @@ pam_sm_setcred(pam_handle_t *pamh,int flags,int argc,CONST char **argv)
 
 static int
 pam_private_session(pam_handle_t *pamh, int flags,
-		    int argc, CONST char **argv,
-		    int status)
+                    int argc, CONST char **argv,
+                    int status)
 {
   CONST char *user;
   int ctrl;
@@ -1296,6 +1435,8 @@ pam_private_session(pam_handle_t *pamh, int flags,
   radius_conf_t config;
 
   ctrl = _pam_parse(argc, argv, &config);
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_private_session\n");
 
   /* grab the user name */
   retval = pam_get_user(pamh, &user, NULL);
@@ -1338,7 +1479,7 @@ pam_private_session(pam_handle_t *pamh, int flags,
 
   sprintf(recv_buffer, "%08d", (int) getpid());
   add_attribute(request, PW_ACCT_SESSION_ID, (unsigned char *) recv_buffer,
-		strlen(recv_buffer));
+                strlen(recv_buffer));
 
   add_int_attribute(request, PW_ACCT_AUTHENTIC, PW_AUTH_RADIUS);
 
@@ -1361,6 +1502,8 @@ pam_private_session(pam_handle_t *pamh, int flags,
 
 error:
 
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_private_session, close config.sockfd and cleanup server list\n");
+
   close(config.sockfd);
   cleanup(config.server);
 
@@ -1369,15 +1512,17 @@ error:
 
 PAM_EXTERN int
 pam_sm_open_session(pam_handle_t *pamh, int flags,
-		    int argc, CONST char **argv)
+                    int argc, CONST char **argv)
 {
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_open_session\n");
   return pam_private_session(pamh, flags, argc, argv, PW_STATUS_START);
 }
 
 PAM_EXTERN int
 pam_sm_close_session(pam_handle_t *pamh, int flags,
-		     int argc, CONST char **argv)
+                     int argc, CONST char **argv)
 {
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_close_session\n");
   return pam_private_session(pamh, flags, argc, argv, PW_STATUS_STOP);
 }
 
@@ -1403,6 +1548,8 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, CONST char **argv)
   radius_conf_t config;
 
   ctrl = _pam_parse(argc, argv, &config);
+
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_chauthtok\n");
 
   /* grab the user name */
   retval = pam_get_user(pamh, &user, NULL);
@@ -1446,8 +1593,9 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, CONST char **argv)
 
   /* preliminary password change checks. */
   if (flags & PAM_PRELIM_CHECK) {
-    if (!password) {		/* no previous password: ask for one */
+    if (!password) {            /* no previous password: ask for one */
       retval = rad_converse(pamh, PAM_PROMPT_ECHO_OFF, "Password: ", &password);
+      TRACEPRINT(LOG_DEBUG, "Trace: Back in pam_sm_chauthtok, after rad_converse\n");
       PAM_FAIL_CHECK;
     }
     
@@ -1481,68 +1629,71 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, CONST char **argv)
      * We're now sure it's the right user.
      * Ask for their new password, if appropriate
      */
+    TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_chauthtok, at new password logic\n");
     
-    if (!new_password) {	/* not found yet: ask for it */
+    if (!new_password) {        /* not found yet: ask for it */
       int new_attempts;
       attempts = 0;
 
       /* loop, trying to get matching new passwords */
       while (attempts++ < 3) {
 
-	/* loop, trying to get a new password */
-	new_attempts = 0;
-	while (new_attempts++ < 3) {
-	  retval = rad_converse(pamh, PAM_PROMPT_ECHO_OFF,
-				"New password: ", &new_password);
-	  PAM_FAIL_CHECK;
-	  
-	  /* the old password may be short.  Check it, first. */
-	  if (strcmp(password, new_password) == 0) { /* are they the same? */
-	    rad_converse(pamh, PAM_ERROR_MSG,
-			 "You must choose a new password.", NULL);
-	    _pam_forget(new_password);
-	    continue;
-	  } else if (strlen(new_password) < 6) {
-	    rad_converse(pamh, PAM_ERROR_MSG, "it's WAY too short", NULL);
-	    _pam_forget(new_password);
-	    continue;
-	  }
+        /* loop, trying to get a new password */
+        new_attempts = 0;
+        while (new_attempts++ < 3) {
+          retval = rad_converse(pamh, PAM_PROMPT_ECHO_OFF,
+                                "New password: ", &new_password);
+          PAM_FAIL_CHECK;
+          
+          /* the old password may be short.  Check it, first. */
+          if (strcmp(password, new_password) == 0) { /* are they the same? */
+            rad_converse(pamh, PAM_ERROR_MSG,
+                         "You must choose a new password.", NULL);
+            _pam_forget(new_password);
+            continue;
+          } else if (strlen(new_password) < 6) {
+            rad_converse(pamh, PAM_ERROR_MSG, "it's WAY too short", NULL);
+            _pam_forget(new_password);
+            continue;
+          }
 
-	  /* insert crypt password checking here */
-	  
-	  break;		/* the new password is OK */
-	}
-	
-	if (new_attempts >= 3) { /* too many new password attempts: die */
-	  retval = PAM_AUTHTOK_ERR;
-	  goto error;
-	}
-	
-	/* make sure of the password by asking for verification */
-	retval =  rad_converse(pamh, PAM_PROMPT_ECHO_OFF,
-			       "New password (again): ", &check_password);
-	PAM_FAIL_CHECK;
-	
-	retval = strcmp(new_password, check_password);
-	_pam_forget(check_password);
-	
-	/* if they don't match, don't pass them to the next module */
-	if (retval != 0) {
-	  _pam_forget(new_password);
-	  rad_converse(pamh, PAM_ERROR_MSG,
-		       "You must enter the same password twice.", NULL);
-	  retval = PAM_AUTHTOK_ERR;
-	  goto error;		/* ??? maybe this should be a 'continue' ??? */
-	}
+          /* insert crypt password checking here */
+          
+          break;                /* the new password is OK */
+        }
+        
+        if (new_attempts >= 3) { /* too many new password attempts: die */
+          retval = PAM_AUTHTOK_ERR;
+          goto error;
+        }
+        
+        /* make sure of the password by asking for verification */
+        retval =  rad_converse(pamh, PAM_PROMPT_ECHO_OFF,
+                               "New password (again): ", &check_password);
+        PAM_FAIL_CHECK;
+        
+        retval = strcmp(new_password, check_password);
+        _pam_forget(check_password);
+        
+        /* if they don't match, don't pass them to the next module */
+        if (retval != 0) {
+          _pam_forget(new_password);
+          rad_converse(pamh, PAM_ERROR_MSG,
+                       "You must enter the same password twice.", NULL);
+          retval = PAM_AUTHTOK_ERR;
+          goto error;           /* ??? maybe this should be a 'continue' ??? */
+        }
 
-	break;			/* everything's fine */
-      }	/* loop, trying to get matching new passwords */
+        break;                  /* everything's fine */
+      } /* loop, trying to get matching new passwords */
 
       if (attempts >= 3) { /* too many new password attempts: die */
-	retval = PAM_AUTHTOK_ERR;
-	goto error;
+        retval = PAM_AUTHTOK_ERR;
+        goto error;
       }
     } /* now we have a new password which passes all of our tests */
+
+    TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_chauthtok, after new password logic\n");
 
     /*
      * Solaris 2.6 calls pam_sm_chauthtok only ONCE, with PAM_PRELIM_CHECK
@@ -1599,9 +1750,11 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, CONST char **argv)
   
   if (ctrl & PAM_DEBUG_ARG) {
     _pam_log(LOG_DEBUG, "password change %s"
-	     , retval==PAM_SUCCESS ? "succeeded":"failed" );
+             , retval==PAM_SUCCESS ? "succeeded":"failed" );
   }
   
+  TRACEPRINT(LOG_DEBUG, "Trace: in pam_sm_chauthtok, close config.sockfd and cleanup server list\n");
+
   close(config.sockfd);
   cleanup(config.server);
 

--- a/pam_radius_auth.conf
+++ b/pam_radius_auth.conf
@@ -8,11 +8,15 @@
 #  lines.  Blank lines or lines beginning with '#' are treated as
 #  comments, and are ignored.  The fields are:
 #
-#  server[:port] secret [timeout]
+#  server{:port} secret {timeout}
 #
-#  the port name or number is optional.  The default port name is
-#  "radius", and is looked up from /etc/services The timeout field is
+#  The port name or number is optional.  The default port name is
+#  "radius", and is looked up from /etc/services. The timeout field is
 #  optional.  The default timeout is 3 seconds.
+#
+#  The server can be a name, an IPv4 address, or an IPv6 address.  Using
+#  a name makes RADIUS dependent on DNS.  An IPv6 address must be
+#  enclosed in square brackets: [fdca:1:2::3:4] or [fdca:1:2::3:4]:1812
 #
 #  If multiple RADIUS server lines exist, they are tried in order.  The
 #  first server to return success or failure causes the module to return
@@ -22,9 +26,10 @@
 #  The timeout field controls how many seconds the module waits before
 #  deciding that the server has failed to respond.
 #
-# server[:port]	shared_secret      timeout (s)
-127.0.0.1	secret             1
-other-server    other-secret       3
+# server{:port}     shared_secret      timeout (seconds)
+127.0.0.1           secret             1
+[::1]:1812          secret             1
+other-server        other-secret       3
 
 #
 # having localhost in your radius configuration is a Good Thing.

--- a/pam_radius_auth.h
+++ b/pam_radius_auth.h
@@ -36,7 +36,7 @@ typedef struct attribute_t {
 
 typedef struct radius_server_t {
   struct radius_server_t *next;
-  struct in_addr ip;
+  struct sockaddr_storage ssip;
   u_short port;
   char *hostname;
   char *secret;

--- a/radius.h
+++ b/radius.h
@@ -125,6 +125,7 @@ typedef struct pw_auth_hdr {
 #define PW_LOGIN_LAT_PORT               63      /* string */
 #define PW_PROMPT                       64      /* integer */
 
+#define PW_NAS_IPV6_ADDRESS				95		/* address */
 /*
  *	INTEGER TRANSLATIONS
  */


### PR DESCRIPTION
---

The notes below describe what was done in getting pam_radius_auth.so to the point of supporting IPv6.
In addition to adding IPv6 support, a TRACE facility was added, hardtab/whitespace was cleaned up, and
some bug fixes were made.

Following is a rough breakdown of the changes:
-   Began with 1.3.17 from tar.gz, which did not include a few changes in the github repo.
  o   Those changes were applied at the end of the project (see below).
-   Removed hard tab characters using vim's :se ts=8 and :se ts=4 and :1,.retab in sections
  o   Did not realign all text to use same indent rules.  Just removed hard tabs.
-   Code changes to reach a first snapshot of IPv6 support:
  o   Can now handle radius server names that resolve to IPv6 (or IPv4)
  o   Can still of course handle IPv4 addresses
  o   Does not yet handle IPv6 addresses completely due to bracket parsing work to be completed
  o   Replaced IPv4-only gethostbyname calls with getaddrinfo calls
  o   Switched from sockaddr/sockaddr_in IPv4-only to generic sockaddr_storage which handles IPv4/IPv6
  o   Set IPV6_V6ONLY to off, allowing one IPv6 socket to handle IPv6 and IPv4 communication.
  o   Commented out no-longer needed IPv4-only validation code (comments in source for this change).
  o   Added TRACEPRINT to aid with development, debugging, and learning how pam_radius_auth works.
-   Near final snapshot:
  o   Implemented bracket handling etc. to support [<ipv6-address>]:port form where :port is still optional.
  o   IPv6 address can be abbreviated forms, such as  [fdca:1:2:3::4]:1812
  o   Improved debug output around port lookup to prevent some failures on odd input in server config file
  o   Modify Makefile to build normal shared library and a trace version using -DTRACEON
  o   Add comments in less obvious parts of code especially where I made changes.
-   Merged in changes from latest github master version of this project, current as of 5/19/2013.
-   Trace version of library:
  o   Modified the Makefile to build a second library, pam_radius_auth_trace.so with tracing enabled.
      \* The trace version can be renamed at runtime to give more debug/trace output if needed.
-   Testing:
  o   Tested with names, IPv6 addresses, and IPv4 addresses against freeradius 2.2
  o   Tested with names, IPv6 addresses, and IPv4 addresses against Windows 2008 NPS
  o   Tested with names and IPv4 addresses against freeradius 2.1 and Windows 2003 IAS
      \* freeradius 2.1 and Windows 2003 IAS do not support IPv6.
-   Contact info:  alan.d.carwile@gmail.com      AC Network Software
                 alan.carwile@hds.com          Hitachi Data Systems
-   Credit also to Kentaro Aoki, whose code changes were referenced and helpful along the way.
  o   http://code.google.com/p/pam-radius-ipv6/
