### PR TITLE
Added 'prompt' option

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -83,5 +83,13 @@ accounting_bug - When used, the accounting response vector is NOT
                  validated.  This option will probably only be necessary
                  on REALLY OLD (i.e. Livingston 1.16) servers.
 
+prompt=string  - Specifies the prompt, without the ': ', that PAM should
+                 display when prompting for the password. This is useful
+                 when using hardware tokens as part of multi-factor
+                 authentication and presenting the same prompt twice would
+                 confuse users.  Use prompt=TokenCode (or some other
+                 relevant string different from Password) in this
+                 situation.
+
 ---------------------------------------------------------------------------
 

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -39,6 +39,9 @@
 #include "radius.h"
 #include "md5.h"
 
+/* Defaults for the prompt option */
+#define MAXPROMPT 33               /* max prompt length, including '\0' */
+#define DEFAULT_PROMPT "Password"  /* default prompt, without the ': '  */
 
 /*************************************************************************
  * Additional RADIUS definitions
@@ -69,6 +72,7 @@ typedef struct radius_conf_t {
 	int accounting_bug;
 	int sockfd;
 	int debug;
+	char prompt[MAXPROMPT];
 } radius_conf_t;
 
 


### PR DESCRIPTION
Hello,

At $WORK we use pam_radius as part of our multi-factor authentication.  We have been re-compiling pam_radius to change the prompt from "Password: " to something else.  The reason is that "Password: " is the same for pam_radius as it is for our other factor and confused users.  This patch, submitted for your approval, adds a prompt option which allows our custom prompt to be handled as a PAM configuration rather than re-compiling pam_radius itself.

I used two defines in pam_radius_auth.h to specify the defaults.  DEFAULT_PROMPT specifies the default prompt of "Password: ".  MAXPROMPT specifies the maximum length of the prompt plus the trailing '\0'.  Excessively long prompts are truncated to (MAXPROMPT - 3) characters so that the ": " and trailing '\0' may be added.  I opted to use a character array rather than a pointer so I wouldn't have to worry about error handling when malloc-ing.  I see that the other defines are at the bottom of the header file but I couldn't put these new defines there without breaking the structure definition.  I ended up putting my two defines above the struct radius_conf_t structure so MAXPROMPT could be used in the array definition.  My thought was to make these two defines the only things that needed to be changed if changes to the defaults were needed.

I'm hoping that you will find this useful and be able to incorporate it, or at least incorporate the functionality.

Thanks,
- Bennett
