### PR TITLE
SURFsara fixes and changes

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1196,6 +1196,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST c
 
 		/* It's full challenge-response, we should have echo on */
 		retval = rad_converse(pamh, PAM_PROMPT_ECHO_ON, challenge, &resp2challenge);
+		PAM_FAIL_CHECK;
 
 		/* now that we've got a response, build a new radius packet */
 		build_radius_packet(request, user, resp2challenge, &config);


### PR DESCRIPTION
Hi,

Please review and accept my changes.

Most important change is a new command-line parameter "max_challenge=#". The trouble is, there are situations in which the (or our) RADIUS server keeps responding with Access-Challenge. `pam_radius_auth` reacts by sending a new Access-Request, and the server will again respond with Access-Challenge. This goes on forever, resulting in an endless loop.
I checked RFC 2865 and it seems correct behavior; the server may request another challenge if it wishes to do so. The RFC says nothing about trying a maximum number of times, and therefore the endless loop situation exists. (Or did I miss something?)

Our RADIUS server never sends Access-Reject, it always responds with Access-Challenge. (Who knows, maybe it's a server bug, or some kind of security feature).
Pressing Ctrl-C in sudo also results in the endless loop.

The other commits fix some smaller issues. Cherry-pick if you like.

Cheers,

```
 --Walter
```
