### PR TITLE
new parameter max_challenge limits number of Access-Challenges

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -91,5 +91,9 @@ prompt=string  - Specifies the prompt, without the ': ', that PAM should
                  relevant string different from Password) in this
                  situation.
 
+max_challenge=# - configure maximum number of challenges that a server
+                  may request. This is a workaround for broken servers
+                  and disabled by default.
+
 ---------------------------------------------------------------------------
 

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -70,6 +70,7 @@ typedef struct radius_conf_t {
 	int localifdown;
 	char *client_id;
 	int accounting_bug;
+	int max_challenge;
 	int sockfd;
 	int debug;
 	char prompt[MAXPROMPT];


### PR DESCRIPTION
Force authentication failure when a certain amount of challenges
has been reached.
This is a workaround for buggy servers that keep issueing
challenges, when they should really send Access-Reject.
The limit is configurable through parameter "max_challenge".
The default is 0, which means the workaround is disabled.
An invalid or negative value also disables this workaround.
