### PR TITLE
add force_prompt option to enforce new password prompt for use with Toke...

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -92,6 +92,10 @@ prompt=string  - Specifies the prompt, without the ': ', that PAM should
                  relevant string different from Password) in this
                  situation.
 
+force_prompt   - Request a new password and not using the previously entered
+                 password. This usefull for multi-factor authentication
+                 when used with a Token.
+
 max_challenge=# - configure maximum number of challenges that a server
                   may request. This is a workaround for broken servers
                   and disabled by default.

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -164,6 +164,9 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 				snprintf(conf->prompt, MAXPROMPT, "%s: ", (char*)*argv+7);
 			}
 
+		} else if (!strcmp(*argv, "force_prompt")) {
+			conf->force_prompt= TRUE;
+
 		} else if (!strncmp(*argv, "max_challenge=", 14)) {
 			conf->max_challenge = atoi(*argv+14);
 
@@ -1135,8 +1138,11 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,int flags,int argc,CONST c
 	request->id = request->vector[0]; /* this should be evenly distributed */
 
 	/* grab the password (if any) from the previous authentication layer */
-	retval = pam_get_item(pamh, PAM_AUTHTOK, (CONST void **) &password);
-	PAM_FAIL_CHECK;
+        if (!config.force_prompt) {
+                DPRINT(LOG_DEBUG, "ignore last_pass, force_prompt set");
+		retval = pam_get_item(pamh, PAM_AUTHTOK, (CONST void **) &password);
+		PAM_FAIL_CHECK;
+        }
 
 	if (password) {
 		password = strdup(password);

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -70,6 +70,7 @@ typedef struct radius_conf_t {
 	int localifdown;
 	char *client_id;
 	int accounting_bug;
+	int force_prompt;
 	int max_challenge;
 	int sockfd;
 	int debug;


### PR DESCRIPTION
I needed this to enable to parallel use of krb5 and radius (with a hardware token). I wanted to enforce the password prompt so that no old passwords are send to the radius token server.
