### PR TITLE
Copy password to buffer before rounding length

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -528,15 +528,15 @@ static void add_password(AUTH_HDR *request, unsigned char type, CONST char *pass
 		length = MAXPASS;
 	}
 
+	memcpy(hashed, password, length);
+	memset(hashed + length, 0, sizeof(hashed) - length);
+
 	if (length == 0) {
 		length = AUTH_PASS_LEN;			/* 0 maps to 16 */
 	} if ((length & (AUTH_PASS_LEN - 1)) != 0) {
 		length += (AUTH_PASS_LEN - 1);		/* round it up */
 		length &= ~(AUTH_PASS_LEN - 1);		/* chop it off */
 	}						/* 16*N maps to itself */
-
-	memcpy(hashed, password, length);
-	memset(hashed + length, 0, sizeof(hashed) - length);
 
 	attr = find_attribute(request, PW_PASSWORD);
 


### PR DESCRIPTION
If I have a password that with a length that is not a multiple of 16, the length is rounded up to 16 before it gets `memcpy`'d into the buffer using the new length. This means my password gets some bogus characters added afterward.

In my testing (on 1bff76afb3b893bb941762419daa2a14657c3b71) , when I authenticate using password `12345`, the contents of `hashed` in `add_password()` shortly before MD5 encryption is:

    0x31, 0x32, 0x33, 0x34, 0x35, 0x0, 0x0, 0x0, 0x58, 0x7b, 0x59, 0x14, 0x31, 0x0, 0x0, 0x0

which is `12345X{Y1` in utf-8. This correlates with my Wireshark capture and FreeRADIUS server log:.

    (47) Received Access-Request Id 64 from x.x.x.x:46769 to y.y.y.y:1812 length 68
    (47)   User-Name = "test"
    (47)   User-Password = "12345\000\000\000X{Y\0241"

This commit fixes the issue by copying the password into the buffer before the length is rounded up to the nearest multiple of 16.