### PR TITLE
add IPv6 support

### DIFF
--- a/pam_radius_auth.conf
+++ b/pam_radius_auth.conf
@@ -14,6 +14,9 @@
 #  "radius", and is looked up from /etc/services The timeout field is
 #  optional.  The default timeout is 3 seconds.
 #
+#  For IPv6 literal addresses, the address has to be surrounded  by
+#  square  brackets as usual. E.g. [2001:0db8:85a3::4].
+#
 #  If multiple RADIUS server lines exist, they are tried in order.  The
 #  first server to return success or failure causes the module to return
 #  success or failure.  Only if a server fails to response is it skipped,
@@ -22,10 +25,10 @@
 #  The timeout field controls how many seconds the module waits before
 #  deciding that the server has failed to respond.
 #
-# server[:port]	shared_secret      timeout (s)
-127.0.0.1	secret             1
-other-server    other-secret       3
-
+# server[:port]             shared_secret      timeout (s)
+127.0.0.1                   secret             1
+other-server                other-secret       3
+[2001:0db8:85a3::4]:1812    other6-secret      1
 #
 # having localhost in your radius configuration is a Good Thing.
 #

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -130,8 +130,8 @@ typedef struct attribute_t {
 
 typedef struct radius_server_t {
 	struct radius_server_t *next;
-	struct in_addr ip;
-	uint16_t port;
+	struct sockaddr_storage ip_storage;
+	struct sockaddr *ip;
 	char *hostname;
 	char *secret;
 	int timeout;
@@ -147,6 +147,7 @@ typedef struct radius_conf_t {
 	int force_prompt;
 	int max_challenge;
 	int sockfd;
+	int sockfd6;
 	int debug;
 	CONST char *conf_file;
 	char prompt[MAXPROMPT];

--- a/src/radius.h
+++ b/src/radius.h
@@ -121,6 +121,8 @@ typedef struct pw_auth_hdr {
 #define PW_LOGIN_LAT_PORT               63      /* string */
 #define PW_PROMPT                       64      /* integer */
 
+#define	PW_NAS_IPV6_ADDRESS	       	95	/* octets */
+
 /*
  *	INTEGER TRANSLATIONS
  */


### PR DESCRIPTION
At the company I work for, xs4all, we use pam_radius on all our servers for authentication of system users, and for authentication of user-services such as imap, pop, smtp, etc. Recently we started with IPv6 only servers and noticed the lack of IPv6 support in pam_radius.

I've added IPv6 support. The git-master version + this patch has been running for a couple of days on ~300 servers - a mix of IPv4 only, IPv4 + IPv6, and IPv6 only.

Please pull :)