### PR TITLE
Add support for Linux VRF (SO_BINDTODEVICE), use per-server sockets if src_ip or vrf are requested

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,17 @@ AC_CHECK_HEADERS(net/if.h, [], [],
   ]
 )
 
+dnl #
+dnl #  Linux requires sys/socket.h before linux/if.h
+dnl #
+AC_CHECK_HEADERS([linux/if.h],[],[],
+  [
+    #if HAVE_SYS_SOCKET_H
+    #  include <sys/socket.h>
+    #endif
+  ]
+)
+
 dnl #############################################################
 dnl #
 dnl #  4. Checks for typedefs
@@ -306,6 +317,7 @@ AC_CHECK_FUNCS( \
   inet_aton \
   inet_pton \
   inet_ntop \
+  setsockopt \
   strlcat \
   strlcpy
 )

--- a/pam_radius_auth.conf
+++ b/pam_radius_auth.conf
@@ -4,16 +4,17 @@
 #  that is readable by root, and NO ONE else.  If anyone other than
 #  root can read this file, then they can spoof responses from the server!
 #
-#  There are 4 fields per line in this file.  There may be multiple
+#  There are 5 fields per line in this file.  There may be multiple
 #  lines.  Blank lines or lines beginning with '#' are treated as
 #  comments, and are ignored.  The fields are:
 #
-#  server[:port] secret [timeout [source_ip]]
+#  server[:port] secret [timeout [source_ip [vrf]]]
 #
 #  the port name or number is optional.  The default port name is
 #  "radius", and is looked up from /etc/services The timeout field is
 #  optional.  The default timeout is 3 seconds.
 #  The source_ip field is optional and the default is none.
+#  The vrf field is optional and the default is none.
 #
 #  For IPv6 literal addresses, the address has to be surrounded  by
 #  square  brackets as usual. E.g. [2001:0db8:85a3::4].
@@ -33,10 +34,18 @@
 #  Note: specifying a timeout field is mandatory due to config parsing,
 #  but if not needed it can be just set to the default of 3.
 #
-# server[:port]             shared_secret      timeout (s)  source_ip
+#  The vrf field can be used on Linux to make the library bind the socket
+#  that connects to that particualar server to a particular VRF.
+#  See: https://www.kernel.org/doc/Documentation/networking/vrf.txt for
+#  more information.
+#  Note: specifying a source_ip field is mandatory due to config parsing,
+#  but if not needed it can be just set to 0.
+#
+# server[:port]             shared_secret      timeout (s)  source_ip            vrf
 127.0.0.1                   secret             3
-other-server                other-secret       5            192.168.1.10
-[2001:0db8:85a3::4]:1812    other6-secret      3            [2001:0db8:85a3::3]
+other-server                other-secret       5            192.168.1.10         vrf-blue
+[2001:0db8:85a3::4]:1812    other6-secret      3            [2001:0db8:85a3::3]  vrf-red
+other-other-server          other-other-secret 5            0                    vrf-blue
 #
 # having localhost in your radius configuration is a Good Thing.
 #

--- a/pam_radius_auth.conf
+++ b/pam_radius_auth.conf
@@ -4,15 +4,16 @@
 #  that is readable by root, and NO ONE else.  If anyone other than
 #  root can read this file, then they can spoof responses from the server!
 #
-#  There are 3 fields per line in this file.  There may be multiple
+#  There are 4 fields per line in this file.  There may be multiple
 #  lines.  Blank lines or lines beginning with '#' are treated as
 #  comments, and are ignored.  The fields are:
 #
-#  server[:port] secret [timeout]
+#  server[:port] secret [timeout [source_ip]]
 #
 #  the port name or number is optional.  The default port name is
 #  "radius", and is looked up from /etc/services The timeout field is
 #  optional.  The default timeout is 3 seconds.
+#  The source_ip field is optional and the default is none.
 #
 #  For IPv6 literal addresses, the address has to be surrounded  by
 #  square  brackets as usual. E.g. [2001:0db8:85a3::4].
@@ -27,10 +28,15 @@
 #  between 3 and 60 seconds.  If they are outside of this range, the
 #  timeouts are clamped to this range.
 #
-# server[:port]             shared_secret      timeout (s)
+#  The source_ip field can be used to make the library bind the socket
+#  that connects to that particular server to a particular IP address.
+#  Note: specifying a timeout field is mandatory due to config parsing,
+#  but if not needed it can be just set to the default of 3.
+#
+# server[:port]             shared_secret      timeout (s)  source_ip
 127.0.0.1                   secret             3
-other-server                other-secret       5
-[2001:0db8:85a3::4]:1812    other6-secret      3
+other-server                other-secret       5            192.168.1.10
+[2001:0db8:85a3::4]:1812    other6-secret      3            [2001:0db8:85a3::3]
 #
 # having localhost in your radius configuration is a Good Thing.
 #

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -592,6 +592,7 @@ static int initialize(radius_conf_t *conf, int accounting)
 	int timeout;
 	int line = 0;
 	char src_ip[MAX_IP_LEN];
+	int valid_src_ip;
 
 	memset(&salocal4, 0, sizeof(salocal4));
 	memset(&salocal6, 0, sizeof(salocal6));
@@ -669,21 +670,24 @@ static int initialize(radius_conf_t *conf, int accounting)
 			memset(&salocal6, 0, sizeof(salocal6));
 			((struct sockaddr *)&salocal4)->sa_family = AF_INET;
 			((struct sockaddr *)&salocal6)->sa_family = AF_INET6;
+			valid_src_ip = -1;
 
 			if (src_ip[0]) {
 				memset(&salocal, 0, sizeof(salocal));
-				get_ipaddr(src_ip, (struct sockaddr *)&salocal, NULL);
-				switch (salocal.ss_family) {
-					case AF_INET:
-						memcpy(&salocal4, &salocal, sizeof(salocal));
-						break;
-					case AF_INET6:
-						memcpy(&salocal6, &salocal, sizeof(salocal));
-						break;
+				valid_src_ip = get_ipaddr(src_ip, (struct sockaddr *)&salocal, NULL);
+				if (valid_src_ip == 0) {
+					switch (salocal.ss_family) {
+						case AF_INET:
+							memcpy(&salocal4, &salocal, sizeof(salocal));
+							break;
+						case AF_INET6:
+							memcpy(&salocal6, &salocal, sizeof(salocal));
+							break;
+					}
 				}
 			}
 
-			if (src_ip[0]) {
+			if (valid_src_ip == 0) {
 				if (initialize_sockets(&server->sockfd, &server->sockfd6, &salocal4, &salocal6) != 0) {
 					goto error;
 				}

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -536,7 +536,6 @@ static int initialize(radius_conf_t *conf, int accounting)
 	int timeout;
 	int line = 0;
 	char src_ip[MAX_IP_LEN];
-	int seen_v6 = 0;
 
 	memset(&salocal4, 0, sizeof(salocal4));
 	memset(&salocal6, 0, sizeof(salocal6));
@@ -615,7 +614,6 @@ static int initialize(radius_conf_t *conf, int accounting)
 						memcpy(&salocal4, &salocal, sizeof(salocal));
 						break;
 					case AF_INET6:
-						seen_v6 = 1;
 						memcpy(&salocal6, &salocal, sizeof(salocal));
 						break;
 				}
@@ -664,8 +662,6 @@ static int initialize(radius_conf_t *conf, int accounting)
 	/* open a IPv6 socket.	Dies if it fails */
 	conf->sockfd6 = socket(AF_INET6, SOCK_DGRAM, 0);
 	if (conf->sockfd6 < 0) {
-		if (!seen_v6)
-			return PAM_SUCCESS;
 		char error_string[BUFFER_SIZE];
 		get_error_string(errno, error_string, sizeof(error_string));
 		_pam_log(LOG_ERR, "Failed to open RADIUS IPv6 socket: %s\n", error_string);

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -136,6 +136,8 @@ typedef struct radius_server_t {
 	char *secret;
 	int timeout;
 	int accounting;
+	int sockfd;
+	int sockfd6;
 } radius_server_t;
 
 typedef struct radius_conf_t {

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -25,6 +25,12 @@
 #include <fcntl.h>
 #include <arpa/inet.h>
 
+#if defined(HAVE_LINUX_IF_H)
+#include <linux/if.h>
+#else
+#define IFNAMSIZ 16 /* fallback to current value */
+#endif
+
 #ifdef HAVE_POLL_H
 #include <poll.h>
 #endif
@@ -138,6 +144,7 @@ typedef struct radius_server_t {
 	int accounting;
 	int sockfd;
 	int sockfd6;
+	char vrf[IFNAMSIZ];
 } radius_server_t;
 
 typedef struct radius_conf_t {


### PR DESCRIPTION
Linux VRF doc: https://www.kernel.org/doc/Documentation/networking/vrf.txt

I've tested this on Debian 9 with the following config file:

```
127.0.0.1 secret 1
192.168.122.122 secret 1 0 vrf-blue
192.168.1.1 secret 1 192.168.1.10
192.168.122.122 secret 1 192.168.122.2 vrf-blue
```

The 192.168.122.x is on a virtual interface enslaved to a VRF.
192.168.1.x is on an interface with 2 IP addresses, and the config asks to use the second one (to test src_ip).

With Wireshark I could observe all 4 packets going out from the correct interfaces.

I've done a small refactor w.r.t. socket initialisation, to avoid code duplication, and in error handling (to correctly clean up all open sockets).

I've also completed one item that was listed as TODO in the code - creating per-server sockets, as it was necessary to be able to use multiple servers in different VRFs. It will also allow to use different src_ip for different servers.