### PR TITLE
Management-Privilege-Level attribute support in pam_radius

### DIFF
--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -161,6 +161,7 @@ typedef struct radius_conf_t {
 	CONST char *conf_file;
 	char prompt[MAXPROMPT];
 	int prompt_attribute;
+	int privilege_level;
 } radius_conf_t;
 
 #endif /* PAM_RADIUS_H */

--- a/src/radius.h
+++ b/src/radius.h
@@ -120,6 +120,7 @@ typedef struct pw_auth_hdr {
 #define PW_PORT_LIMIT                   62      /* integer */
 #define PW_LOGIN_LAT_PORT               63      /* string */
 #define PW_PROMPT                       76      /* integer */
+#define PW_MANAGEMENT_PRIVILEGE_LEVEL   136     /* integer */
 
 #define	PW_NAS_IPV6_ADDRESS	       	95	/* octets */
 


### PR DESCRIPTION
Management-Privilege-Level attribute support in pam_radius.

ReadMe:
1. privilege_level config option is added

2. 'Privilege' environment variable is added which can be used by the application for granting different management access levels to the users.
