### PR TITLE
Fix a few typos found by codespell

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -113,7 +113,7 @@ jobs:
         sudo systemctl start freeradius
 
         echo "#######################################################"
-        echo "## Show processs"
+        echo "## Show processes"
         ps aux | grep -E "([r]adius|[s]sh|[s]yslog)"
 
     - name: "Content of /etc/ssh/sshd_config"
@@ -157,7 +157,7 @@ jobs:
     #  If the CI has failed and the branch is ci-debug then we start a tmate
     #  session to provide interactive shell access to the session.
     #
-    #  The SSH rendezvous point will be emited continuously in the job output,
+    #  The SSH rendezvous point will be emitted continuously in the job output,
     #  which will look something like:
     #
     #      SSH: ssh VfuX8SrNuU5pGPMyZcz7TpJTa@sfo2.tmate.io

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -183,7 +183,7 @@ jobs:
         sudo /usr/sbin/radiusd
 
         echo "#######################################################"
-        echo "## Show processs"
+        echo "## Show processes"
         ps aux | grep -E "([r]adius|[s]sh|[s]yslog)"
 
     - name: "Content of /etc/ssh/sshd_config"
@@ -227,7 +227,7 @@ jobs:
     #  If the CI has failed and the branch is ci-debug then we start a tmate
     #  session to provide interactive shell access to the session.
     #
-    #  The SSH rendezvous point will be emited continuously in the job output,
+    #  The SSH rendezvous point will be emitted continuously in the job output,
     #  which will look something like:
     #
     #      SSH: ssh VfuX8SrNuU5pGPMyZcz7TpJTa@sfo2.tmate.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         sudo systemctl start freeradius
 
         echo "#######################################################"
-        echo "## Show processs"
+        echo "## Show processes"
         ps aux | grep -E "([r]adius|[s]sh|[s]yslog)"
 
     - name: Content of /etc/ssh/sshd_config
@@ -200,7 +200,7 @@ jobs:
     #  If the CI has failed and the branch is ci-debug then we start a tmate
     #  session to provide interactive shell access to the session.
     #
-    #  The SSH rendezvous point will be emited continuously in the job output,
+    #  The SSH rendezvous point will be emitted continuously in the job output,
     #  which will look something like:
     #
     #      SSH: ssh VfuX8SrNuU5pGPMyZcz7TpJTa@sfo2.tmate.io

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ rpmbuild/SOURCES/pam_radius-$(VERSION).tar.bz2: pam_radius-$(VERSION).tar.bz2
 
 rpm: rpmbuild/SOURCES/pam_radius-$(VERSION).tar.bz2
 	@if ! yum-builddep -q -C --assumeno --define "_version $(VERSION)" redhat/pam_radius_auth.spec 1> /dev/null 2>&1; then \
-		echo "ERROR: Required depdendencies not found, install them with: yum-builddep redhat/pam_radius_auth.spec"; \
+		echo "ERROR: Required dependencies not found, install them with: yum-builddep redhat/pam_radius_auth.spec"; \
 		exit 1; \
 	fi
 	@QA_RPATHS=0x0003 rpmbuild --define "_version $(VERSION)" --define "_topdir `pwd`/rpmbuild" -bb redhat/pam_radius_auth.spec

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alan DeKok <aland@freeradius.org>
 
 When building under clang and some later versions of GCC with `--enable-developer`, you can add the following flags:
 
-- `--enable-address-sanitizer`, enables address sansitizer (detects use after free issues, and out of bounds accesses).
+- `--enable-address-sanitizer`, enables address sanitizer (detects use after free issues, and out of bounds accesses).
 - `--enable-leak-sanitizer`, enables leak sanitizer (detects memory leaks).
 
 ## Packages

--- a/USAGE
+++ b/USAGE
@@ -15,7 +15,7 @@ relevant in for all uses of the module.
 
 debug          - print out extensive debugging information via pam_log.
                  These messages generally end up being handled by
-                 sylog(), and go to /var/log/messages.  Depending on
+                 syslog(), and go to /var/log/messages.  Depending on
                  your host operating system, the log messages may be
                  elsewhere.
 		 You should generally use the debug option when first

--- a/configure.ac
+++ b/configure.ac
@@ -530,7 +530,7 @@ if test "x$developer" = "xyes"; then
   fi
 
   dnl #
-  dnl #  Can't use mutliple -fsanitize flags, so we need to combine
+  dnl #  Can't use multiple -fsanitize flags, so we need to combine
   dnl #  the values into one.
   dnl #
   fsanitizeflags=

--- a/src/md5.h
+++ b/src/md5.h
@@ -8,7 +8,7 @@
  *	Other projects seem to use endian.h and variants, but these are
  *	in non standard locations, and may mess up cross compiling.
  *
- *	Here at least the endianess can be set explicitly with
+ *	Here at least the endianness can be set explicitly with
  *	-DLITTLE_ENDIAN or -DBIG_ENDIAN.
  */
 #if !defined(LITTLE_ENDIAN) && !defined(BIG_ENDIAN)

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1486,7 +1486,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 		}
 	}
 
-	/* Whew! Done the pasword checks, look for an authentication acknowledge */
+	/* Whew! Done the password checks, look for an authentication acknowledge */
 	if (response->code == PW_AUTHENTICATION_ACK) {
 		retval = PAM_SUCCESS;
 
@@ -1525,7 +1525,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 			val = ntohl(*((int *)a_mpl->data));
 			sprintf(priv, "Privilege=%d", val);
 
-			/* Save Management-Privilege-Level value in PAM environment variable 'Privilige' */
+			/* Save Management-Privilege-Level value in PAM environment variable 'Privilege' */
 			retval = pam_putenv(pamh, priv);
 			if(retval != PAM_SUCCESS) {
 				_pam_log(LOG_ERR, "unable to set PAM environment variable : Privilege");


### PR DESCRIPTION
Most are not visible by end-users, so fixing them might not be a priority. Still, the changes are very simple, they cannnot break anything.