### PR TITLE
Declare C string constants using array syntax

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -36,10 +36,10 @@
 #define DPRINT if (debug) _pam_log
 
 /* internal data */
-static CONST char *pam_module_name = "pam_radius_auth";
+static CONST char pam_module_name[] = "pam_radius_auth";
 
 /* module version */
-static CONST char *pam_module_version = PAM_RADIUS_VERSION_STRING
+static CONST char pam_module_version[] = PAM_RADIUS_VERSION_STRING
 #ifndef NDEBUG
 	" DEVELOPER BUILD - "
 #endif


### PR DESCRIPTION
Avoid pointer syntax when possible.

They are different, the array syntax generates smaller, faster code.

See for example:
https://eklitzke.org/declaring-c-string-constants-the-right-way