### PR TITLE
pam_radius_auth: stop printing password

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1372,7 +1372,6 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 
 	if (old_password) {
 		password = strdup(old_password);
-		DPRINT(LOG_DEBUG, "Got password %s", password);
 	}
 
 	/* no previous password: maybe get one from the user */


### PR DESCRIPTION
Printing plain text passwords should be avoided. Even if it's in a root
owned file like /var/log/secure