### PR TITLE
Adding custom challenge option

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -96,6 +96,12 @@ force_prompt   - Request a new password and not using the previously entered
                  password. This useful for multi-factor authentication
                  when used with a Token.
 
+challenge=string - Specifies a custom challenge prompt. This will substitute
+                   any challenge prompt inside the Reply-Message attribute of a 
+                   Access-Challenge request to a custom prompt. Use 
+                   challenge="Enter your TOTP: " (or some other relevant string)
+                   in this situation.
+
 max_challenge=# - configure maximum number of challenges that a server
                   may request. This is a workaround for broken servers
                   and disabled by default.

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1352,6 +1352,14 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 		return PAM_USER_UNKNOWN;
 	}
 
+    /* Print banner */
+    
+    if (config.banner){
+        
+        printf("%s",config.banner);
+        
+    }
+
 	DPRINT(LOG_DEBUG, "Got user name: '%s'", user);
 
 	if (ctrl & PAM_RUSER_ARG) {
@@ -1386,6 +1394,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 	/* now we've got a socket open, so we've got to clean it up on error */
 #undef PAM_FAIL_CHECK
 #define PAM_FAIL_CHECK if (retval != PAM_SUCCESS) { goto do_next; }
+
 
 
 	/* build and initialize the RADIUS packet */

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1356,7 +1356,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
     
     if (config.banner){
         DPRINT(LOG_DEBUG, "A banner message is configured. Printing it.");
-        printf("%s",config.banner);
+        printf("Oh, no banner? %s",config.banner);
         
     }
 

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -230,7 +230,7 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 
 		_pam_log(LOG_DEBUG, "DEBUG: conf='%s' use_first_pass=%s try_first_pass=%s skip_passwd=%s retry=%d " \
 							"localifdown=%s client_id='%s' accounting_bug=%s ruser=%s prompt='%s' force_prompt=%s "\
-							"prompt_attribute=%s max_challenge=%d privilege_level=%s",
+							"prompt_attribute=%s challenge=%s max_challenge=%d privilege_level=%s",
 				conf->conf_file,
 				print_bool(ctrl & PAM_USE_FIRST_PASS),
 				print_bool(ctrl & PAM_TRY_FIRST_PASS),
@@ -243,6 +243,7 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 				conf->prompt,
 				print_bool(conf->force_prompt),
 				print_bool(conf->prompt_attribute),
+                conf->challenge,
 				conf->max_challenge,
 				print_bool(conf->privilege_level)
 		);

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -193,20 +193,6 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 				snprintf(conf->challenge, MAXCHALLENGE, "%s: ", (arg+10));
 			}
 
-		} else if (!strncmp(arg, "banner=", 7)) {
-			if (!strncmp(conf->banner, (arg+7), MAXBANNER)) {
-				_pam_log(LOG_WARNING, "ignoring duplicate '%s'", arg);
-			} else {
-				/* truncate excessive bannerss to (MAXBANNER - 3) length */
-				if (strlen((arg+7)) >= (MAXBANNER - 3)) {
-					*((arg + 7) + (MAXBANNER - 3)) = '\0';
-				}
-
-				/* set a banner */
-				memset(conf->banner, 0, sizeof(conf->banner));
-				snprintf(conf->banner, MAXCHALLENGE, "%s: ", (arg+7));
-			}
-
 		} else if (!strcmp(arg, "force_prompt")) {
 			conf->force_prompt = TRUE;
 
@@ -223,6 +209,7 @@ static int _pam_parse(int argc, CONST char **argv, radius_conf_t *conf)
 			_pam_log(LOG_WARNING, "unrecognized option '%s'", arg);
 		}
 	}
+
 
 	if (conf->debug) {
 #define print_bool(cond) (cond) ? "yes" : "no"
@@ -1311,6 +1298,8 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, const char *message, 
 		return retval; \
 	}
 
+
+
 PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int argc, CONST char **argv)
 {
 	CONST char *user = NULL;
@@ -1352,13 +1341,6 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 		return PAM_USER_UNKNOWN;
 	}
 
-    /* Print banner */
-    
-    if (config.banner){
-        DPRINT(LOG_DEBUG, "A banner message is configured. Printing it.");
-        retval = rad_converse(pamh, PAM_TEXT_INFO, config.banner, NULL);
-        
-    }
 
 	DPRINT(LOG_DEBUG, "Got user name: '%s'", user);
 

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1356,7 +1356,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
     
     if (config.banner){
         DPRINT(LOG_DEBUG, "A banner message is configured. Printing it.");
-        printf("Oh, no banner? %s",config.banner);
+        retval = rad_converse(pamh, PAM_TEXT_INFO, config.prompt, NULL);
         
     }
 

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1355,7 +1355,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
     /* Print banner */
     
     if (config.banner){
-        
+        DPRINT(LOG_DEBUG, "A banner message is configured. Printing it.");
         printf("%s",config.banner);
         
     }

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1474,7 +1474,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 			retval = PAM_AUTHINFO_UNAVAIL;
 			goto do_next;
 		}
-        if (config.challenge){
+        if (strlen(config.challenge) != 0){
             memcpy(challenge,config.challenge,sizeof(config.challenge));
             challenge[strlen(config.challenge)] = 0;
         } else {

--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1356,7 +1356,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
     
     if (config.banner){
         DPRINT(LOG_DEBUG, "A banner message is configured. Printing it.");
-        retval = rad_converse(pamh, PAM_TEXT_INFO, config.prompt, NULL);
+        retval = rad_converse(pamh, PAM_TEXT_INFO, config.banner, NULL);
         
     }
 

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -58,6 +58,12 @@
 #define MAXPROMPT 33               /* max prompt length, including '\0' */
 #define DEFAULT_PROMPT "Password"  /* default prompt, without the ': '  */
 
+/* Custom challenge length */
+#define MAXCHALLENGE 90
+
+/* Banner length for optional banner string */
+#define MAXBANNER 200
+
 
 /*************************************************************************
  * Platform specific defines
@@ -98,6 +104,7 @@
 #define PAM_USE_FIRST_PASS 4
 #define PAM_TRY_FIRST_PASS 8
 #define PAM_RUSER_ARG      16
+
 
 
 /* buffer size for IP address in string form */
@@ -185,6 +192,8 @@ typedef struct radius_conf_t {
 	int debug;
 	CONST char *conf_file;
 	char prompt[MAXPROMPT];
+    char challenge[MAXCHALLENGE];
+    char banner[MAXBANNER];
 	int prompt_attribute;
 	int privilege_level;
 } radius_conf_t;

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -61,9 +61,6 @@
 /* Custom challenge length */
 #define MAXCHALLENGE 90
 
-/* Banner length for optional banner string */
-#define MAXBANNER 200
-
 
 /*************************************************************************
  * Platform specific defines
@@ -193,7 +190,6 @@ typedef struct radius_conf_t {
 	CONST char *conf_file;
 	char prompt[MAXPROMPT];
     char challenge[MAXCHALLENGE];
-    char banner[MAXBANNER];
 	int prompt_attribute;
 	int privilege_level;
 } radius_conf_t;


### PR DESCRIPTION
We are proposing adding a `challenge` option for `pam_radius` so that the user can configure a prompt to replace the one sent by the radius server on the `Reply-Message` of an `Access-Challenge` request. 

This can be useful in situation where the message of the server isn't very explanatory or not very compatible with the linux command line.

If this gets approved, I will also work on a `challenge_suffix` option, so that the user can configure suffixes for server-sent prompts, such as `: `, as many servers do not send well formatted prompts.

I was also thinking about adding a `banner` option, and actually wrote the code for it, but I guess it can be annoying to have the same message displayed on and on again after a failed attempt. And to get the message written only once there are maybe better solutions such as `pam_echo` out there.
