### PR TITLE
Remove unused `utmp` interface

### DIFF
--- a/configure
+++ b/configure
@@ -5693,12 +5693,6 @@ then :
   printf "%s\n" "#define HAVE_UNISTD_H 1" >>confdefs.h
 
 fi
-ac_fn_c_check_header_compile "$LINENO" "utmp.h" "ac_cv_header_utmp_h" "$ac_includes_default"
-if test "x$ac_cv_header_utmp_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_UTMP_H 1" >>confdefs.h
-
-fi
 
 
 ac_fn_c_check_header_compile "$LINENO" "security/pam_appl.h" "ac_cv_header_security_pam_appl_h" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -274,8 +274,7 @@ AC_CHECK_HEADERS( \
 	syslog.h \
 	poll.h \
 	time.h \
-	unistd.h \
-	utmp.h
+	unistd.h
 )
 
 AC_CHECK_HEADERS(security/pam_appl.h pam/pam_appl.h)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -128,9 +128,6 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to 1 if you have the <utmp.h> header file. */
-#undef HAVE_UTMP_H
-
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/src/pam_radius_auth.h
+++ b/src/pam_radius_auth.h
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <syslog.h>
 #include <stdarg.h>
-#include <utmp.h>
 #include <time.h>
 #include <netinet/in.h>
 #include <netdb.h>


### PR DESCRIPTION
It has been identified that the `utmp` interface will have problems in 2038 on 64-bit architectures. I was reviewing the code to replace it with another implementation, but it doesn't seem to be used anywhere. Therefore, I am removing it.

If my understanding is incorrect, please indicate its usage so that I can evaluate the substitution.