### PR TITLE
Fix static warning message.

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1972,6 +1972,8 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, CONST c
 	return retval;
 }
 
+#ifdef PAM_STATIC
+
 /*
  *	Do nothing for account management. This is apparently needed by
  *	some programs.
@@ -1980,8 +1982,6 @@ PAM_EXTERN int pam_sm_acct_mgmt(UNUSED pam_handle_t *pamh, UNUSED int flags, UNU
 {
 	return PAM_SUCCESS;
 }
-
-#ifdef PAM_STATIC
 
 /* static module data */
 struct pam_module _pam_radius_modstruct = {


### PR DESCRIPTION
eg:
```
pam_radius_auth.c:1980:16: warning: no previous prototype for function 'pam_sm_acct_mgmt' [-Wmissing-prototypes]
 1980 | PAM_EXTERN int pam_sm_acct_mgmt(UNUSED pam_handle_t *pamh, UNUSED int flags, UNUSED int argc, UNUSED CONST char **argv)
  1 Fix warning assignment discards qualifiers
      |                ^
pam_radius_auth.c:1980:12: note: declare 'static' if the function is not intended to be used outside of this translation unit
 1980 | PAM_EXTERN int pam_sm_acct_mgmt(UNUSED pam_handle_t *pamh, UNUSED int flags, UNUSED int argc, UNUSED CONST char **argv)
      |            ^
      |            static
```