### PR TITLE
Fix warning assignment discards qualifiers

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1274,7 +1274,8 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, const char *message, 
 	int retval;
 
 	resp_msg.msg_style = msg_style;
-	resp_msg.msg = message;
+	memcpy(&resp_msg.msg, message, sizeof(resp_msg.msg));
+
 	msg[0] = &resp_msg;
 
 	/* grab the password */


### PR DESCRIPTION
eg:

```
pam_radius_auth.c:1277:15: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 1277 |         resp_msg.msg = message;
      |                      ^ ~~~~~~~
```