### PR TITLE
Fix pam_message handling in pam_radius_auth.c

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1274,7 +1274,7 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, const char *message, 
 	int retval;
 
 	resp_msg.msg_style = msg_style;
-	memcpy(&resp_msg.msg, message, sizeof(resp_msg.msg));
+	resp_msg.msg       = message;
 
 	msg[0] = &resp_msg;
 


### PR DESCRIPTION
Pointer error: According to the definition of struct pam_message 

struct pam_message {
    int msg_style;
    const char *msg;
};

the member msg is a pointer to a string and not the address of the string.

Previous code may lead to segmentation fault inside application-defined callback trying to access the msg.