### PR TITLE
Fix pointer bug and char type in rad_converse()

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1272,9 +1272,14 @@ static int rad_converse(pam_handle_t *pamh, int msg_style, const char *message, 
 	CONST struct pam_message *msg[1];
 	struct pam_response *resp = NULL;
 	int retval;
+	char *message_char;
 
-	resp_msg.msg_style = msg_style;
-	memcpy(&resp_msg.msg, message, sizeof(resp_msg.msg));
+        // in some systems we need 'char' for resp_msg.msg instead of 'const char'
+        message_char = malloc(strlen(message)+1);
+        strcpy(message_char,message);
+
+        resp_msg.msg_style = msg_style;
+        resp_msg.msg = message_char;
 
 	msg[0] = &resp_msg;
 


### PR DESCRIPTION
This line
memcpy(&resp_msg.msg, message, sizeof(resp_msg.msg));

is really a complicated hack for casting 'cons char' to 'char'. 

And it is causing various faults in PAM apps, like this one: sshd-mfa[203808] general protection fault ip:7ff15c4bef3d sp:7ffd94cc5da8 error:0 in libc.so.6

Actually it should be:
memcpy(&resp_msg.msg, &message, sizeof(resp_msg.msg));

Better way seems to be to copy the string into a char typed memory.