### PR TITLE
When receiving a response from the radius server, check the source of the response.

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -354,12 +354,18 @@ static int host2server(int debug, radius_server_t *server)
 	return retval;
 }
 
-static int ipaddr_eq(struct sockaddr_storage *addr_A, struct sockaddr_storage *addr_B)
+/** Compare two sockaddr for equality
+ * @param[in]  addr_A    First address
+ * @param[in]  addr_B    Second address
+ * @return
+ *  - return TRUE if address family, and address match, FALSE otherwise.
+ */
+static int ipaddr_eq(struct sockaddr *addr_A, struct sockaddr *addr_B)
 {
-	if (addr_A->ss_family != addr_B->ss_family) {
+	if (addr_A->sa_family != addr_B->sa_family) {
 		return FALSE;
 	}
-	switch(addr_A->ss_family){
+	switch(addr_A->sa_family){
 		case AF_INET:
 			return ((struct sockaddr_in *)addr_A)->sin_addr.s_addr == ((struct sockaddr_in *)addr_B)->sin_addr.s_addr;
 		case AF_INET6:
@@ -369,7 +375,7 @@ static int ipaddr_eq(struct sockaddr_storage *addr_A, struct sockaddr_storage *a
 				16
 			) == 0;
 		default:
-			_pam_log(LOG_ERR, "Unsupported address family %s.", addr_A->ss_family);
+			_pam_log(LOG_ERR, "Unsupported address family %s.", addr_A->sa_family);
 			return FALSE;
 	}
 }
@@ -1150,7 +1156,7 @@ static int talk_radius(radius_conf_t *conf, AUTH_HDR *request, AUTH_HDR *respons
 
 				/* there's data, see if it's valid */
 				} else {
-					if (!ipaddr_eq(&response_addr, &(server->ip_storage))) {
+					if (!ipaddr_eq((struct sockaddr *) &response_addr, server->ip)) {
 						retval = getnameinfo((struct sockaddr *)&response_addr, response_addr_len,
 								response_addr_str, INET_ADDRSTRLEN,
 								NULL, 0, NI_NUMERICHOST);


### PR DESCRIPTION
Hi, Please accept my apologies if this is not a suitable addition.
I am primarily a sysadmin, so deal with configuration more than code, but I understood the problem well enough, and hope I understand sufficiently how to address it.
I welcome any changes if the naming or structure could be improved.


## What
Check that the source of a received response matches the expected radius server

## Why
If multiple radius servers are configured, and one takes longer than the timeout to reply (but does reply), the reply causes a log of:
> packet from RADIUS server $current_server failed verification: The shared secret is probably incorrect.

and the listening socket is closed before the reply actually from the current server is received.

This is particularly a problem when due to additional checks (in our case, certain MFA methods with an NPS server) delay the response.

## How
- Add the function `ipaddr_eq` to check for the equality of two `sockaddr`s

## Testing
I have tested this with a pam authenticated sshd, configured to talk to an NPS radius server.

Without this change:
- ✅ a correct reply from the correct server is accepted.
- ❌ a correct reply from a previously timed out server causes the port to be closed.
- ❌ a completely incorrect packet from any source to the port socket causes the port to be closed.

With this change:
- ✅ a correct reply from the correct server is accepted.
- ✅ a correct reply from a previously timed out server is discarded, and the port continues listening.
- ✅ a completely incorrect packet from any other source is discarded, and the port continues listening.

I have also tested the `ipaddr_eq` function by itself, to hopefully sufficiently check it with IPv4, IPv6 and a mix (with IPv4-mapped IPv6 addresses).