### PR TITLE
Makefile: Add DESTDIR to support cross-builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,8 @@ clean:
 #
 .PHONY: install
 install: all
-	@mkdir -p /lib/security
-	install -m 0644 pam_radius_auth.so /lib/security
-	install -m 0644 pam_radius_auth.conf /etc/pam_radius_auth.conf
+	install -Dm 0644 pam_radius_auth.so $(DESTDIR)/lib/security/pam_radius_auth.so
+	install -Dm 0644 pam_radius_auth.conf $(DESTDIR)/etc/pam_radius_auth.conf
 
 ######################################################################
 #


### PR DESCRIPTION
As the present will require sudo permission, 
DESTDIR will help the user change the install location as needed. 
Using -D will create the destination directory, eliminating the need for a separate mkdir command.