### PR TITLE
pam_radius: Fix install permissions to preserve executable bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ clean:
 #
 .PHONY: install
 install: all
-	install -Dm 0644 pam_radius_auth.so $(DESTDIR)/lib/security/pam_radius_auth.so
+	install -Dm 0755 pam_radius_auth.so $(DESTDIR)/lib/security/pam_radius_auth.so
 	install -Dm 0644 pam_radius_auth.conf $(DESTDIR)/etc/pam_radius_auth.conf
 
 ######################################################################


### PR DESCRIPTION
Changed file mode from 0655 to 0755 during install of pam_radius_auth.so to ensure the shared library remains executable as required by PAM.