### PR TITLE
Fix heap buffer overflow in Class attribute handling

### DIFF
--- a/src/pam_radius_auth.c
+++ b/src/pam_radius_auth.c
@@ -1683,7 +1683,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, UNUSED int flags, int arg
 
 			if ((buf = malloc(attr_class->length - 1))) {
 				buf[0] = attr_class->length - 2;
-				memcpy(buf + 1, attr_class->data, attr_class->length - 1);
+				memcpy(buf + 1, attr_class->data, attr_class->length - 2);
 
 				if (pam_set_data(pamh, "pam_radius_auth_class", (void*)buf, _int_free) != PAM_SUCCESS) {
 					_pam_log(LOG_ERR, "Could not save RADIUS Class: pam_set_data failed");


### PR DESCRIPTION
# Fix heap buffer overflow in Class attribute handling

Fixes #120.

The Class attribute handler in `pam_sm_authenticate()` allocates a buffer of `attr_class->length - 1` bytes but copies `attr_class->length - 1` bytes starting at offset 1, writing `length` bytes total and overflowing the allocation by one byte (it also over-reads the source attribute by one byte).

The stored blob is `[data_len][data...]`, where data is `length - 2` bytes. The copy must be `length - 2`, which matches both the allocation and the consumer in `pam_private_session()` (`add_attribute(..., class + 1, class[0])`, with `class[0] == length - 2`).

Triggered by any `Access-Accept` carrying a `Class` attribute; observed as `*** buffer overflow detected ***` on `_FORTIFY_SOURCE=3` builds (Ubuntu 24.04), silent heap corruption on lower levels.

Ubuntu 22.04
pamtester: performing operation - authenticate
Password: 
pamtester: successfully authenticated

Ubuntu 24.04
pamtester: performing operation - authenticate
Password: 
*** buffer overflow detected ***: terminated
Aborted (core dumped)